### PR TITLE
Add responses dashboard endpoint

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "16.7.0",
+            "platform_release": "17.5.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.5.0: Fri Apr 13 19:32:32 PDT 2018; root:xnu-4570.51.2~1/RELEASE_X86_64",
             "python_full_version": "3.6.3",
             "python_version": "3.6",
             "sys_platform": "darwin"
@@ -99,9 +99,10 @@
         },
         "jdcal": {
             "hashes": [
-                "sha256:b760160f8dc8cc51d17875c6b663fafe64be699e10ce34b6a95184b5aa0fdc9e"
+                "sha256:948fb8d079e63b4be7a69dd5f0cd618a0a57e80753de8248fd786a8a20658a07",
+                "sha256:ea0a5067c5f0f50ad4c7bdc80abad3d976604f6fb026b0b3a17a9d84bb9046c9"
             ],
-            "version": "==1.3"
+            "version": "==1.4"
         },
         "jinja2": {
             "hashes": [
@@ -205,10 +206,17 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450",
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
+        },
+        "configparser": {
+            "hashes": [
+                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.5.0"
         },
         "coverage": {
             "hashes": [
@@ -251,6 +259,16 @@
             ],
             "version": "==4.5.1"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1",
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
         "flake8": {
             "hashes": [
                 "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37",
@@ -267,6 +285,8 @@
         },
         "pluggy": {
             "hashes": [
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5",
                 "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff"
             ],
             "version": "==0.6.0"
@@ -280,9 +300,7 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9",
-                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766"
             ],
             "version": "==2.3.1"

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from flask import _app_ctx_stack
 
+
 def initialise_db(app):
     app.db = create_connection(app.config['DATABASE_URI'])
 
@@ -43,12 +44,14 @@ CORS(app)
 api = Api(title='rm-reporting', default='info', default_label="")
 
 response_chasing_api = Namespace('response-chasing', path='/reporting-api/v1/response-chasing')
+response_dashboard_api = Namespace('response-dashboard', path='/reporting-api/v1/response-dashboard')
 
 api.add_namespace(response_chasing_api)
+api.add_namespace(response_dashboard_api)
 
 from rm_reporting.resources.info import Info  # NOQA # pylint: disable=wrong-import-position
 from rm_reporting.resources.response_chasing import ResponseChasingDownload  # NOQA # pylint: disable=wrong-import-position
-
+from rm_reporting.resources.responses_dashboard import ResponseDashboard  # NOQA # pylint: disable=wrong-import-position
 api.init_app(app)
 
 

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -53,5 +53,3 @@ from rm_reporting.resources.info import Info  # NOQA # pylint: disable=wrong-imp
 from rm_reporting.resources.response_chasing import ResponseChasingDownload  # NOQA # pylint: disable=wrong-import-position
 from rm_reporting.resources.responses_dashboard import ResponseDashboard  # NOQA # pylint: disable=wrong-import-position
 api.init_app(app)
-
-

--- a/rm_reporting/common/validators.py
+++ b/rm_reporting/common/validators.py
@@ -3,7 +3,7 @@ import uuid
 
 def is_valid_uuid(uuid_string):
 
-    if len(uuid_string) > 36:
+    if len(uuid_string) > 35:
         return False
 
     try:

--- a/rm_reporting/common/validators.py
+++ b/rm_reporting/common/validators.py
@@ -1,0 +1,10 @@
+import uuid
+
+
+def is_valid_uuid(uuid_string):
+    try:
+        # Check if data is in valid UUID format
+        str(uuid.UUID(uuid_string))
+        return True
+    except ValueError:
+        return False

--- a/rm_reporting/common/validators.py
+++ b/rm_reporting/common/validators.py
@@ -2,9 +2,14 @@ import uuid
 
 
 def is_valid_uuid(uuid_string):
+
+    if len(uuid_string) > 36:
+        return False
+
     try:
         # Check if data is in valid UUID format
         str(uuid.UUID(uuid_string))
-        return True
     except ValueError:
         return False
+    else:
+        return True

--- a/rm_reporting/common/validators.py
+++ b/rm_reporting/common/validators.py
@@ -1,15 +1,10 @@
 import uuid
 
 
-def is_valid_uuid(uuid_string):
-
-    if len(uuid_string) > 35:
-        return False
+def parse_uuid(uuid_string):
 
     try:
         # Check if data is in valid UUID format
-        str(uuid.UUID(uuid_string))
+        return str(uuid.UUID(uuid_string))
     except ValueError:
         return False
-    else:
-        return True

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -66,7 +66,8 @@ class ResponseChasingDownload(Resource):
                         "ba.business_id = b.party_uuid " \
                         "ORDER BY cg.status, cg.sampleunitref) " \
                         "SELECT bd.status, bd.sampleunitref, bd.name, e.status,  " \
-                        "CONCAT(r.first_name, ' ', r.last_name), r.telephone, r.email_address, r.status FROM business_data bd " \
+                        "CONCAT(r.first_name, ' ', r.last_name), r.telephone, r.email_address," \
+                        " r.status FROM business_data bd " \
                         "LEFT JOIN partysvc.enrolment e " \
                         f"ON e.business_id = bd.business_uuid AND e.survey_id = '{survey_id}' " \
                         "LEFT JOIN partysvc.respondent r ON e.respondent_id = r.id " \

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -48,10 +48,10 @@ class ResponseDashboard(Resource):
                             'INNER JOIN casesvc.casegroup cg ON c.casegroupFK = cg.casegroupPK '
                             'GROUP BY cg.sampleunitref, c.sampleunittype, c.casePK) events) as data_records '
                             'WHERE case_ref IN '
-                            '(SELECT t.caseref FROM casesvc."case" t '
-                            'WHERE t.casegroupid IN '
-                            '(SELECT t.id "Group ID" FROM casesvc.casegroup t '
-                            'WHERE t.collectionexerciseid = :collection_exercise_id))')
+                            '(SELECT c.caseref FROM casesvc.case c '
+                            'WHERE c.casegroupid IN '
+                            '(SELECT cg.id "Group ID" FROM casesvc.casegroup cg '
+                            'WHERE cg.collectionexerciseid = :collection_exercise_id))')
 
         if not is_valid_uuid(collection_exercise_id):
             logger.debug("Malformed collection exercise ID", invalid_id=collection_exercise_id)

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+import logging
+
+from flask import json, Response
+from flask_restplus import Resource
+from sqlalchemy import text
+from structlog import wrap_logger
+
+from rm_reporting import app, response_dashboard_api
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+@response_dashboard_api.route('/<collection_exercise_id>')
+class ResponseDashboard(Resource):
+
+    @staticmethod
+    def get(collection_exercise_id):
+
+        engine = app.db.engine
+
+        collex_status = "SELECT COUNT(DISTINCT(sample_unit_ref)) \"Sample Size\", " \
+                        "SUM(enrolled) \"Total Enrolled\", SUM(downloaded) \"Total Downloaded\", " \
+                        "SUM(uploaded) \"Total Uploaded\" " \
+                        "FROM " \
+                        "(SELECT " \
+                        "events.sampleunitref sample_unit_ref, events.sampleunittype, events.caseref case_ref, " \
+                        "events.respondent_enrolled enrolled, events.collection_instrument_downloaded_ind downloaded, " \
+                        "events.successful_response_upload_ind uploaded FROM (SELECT cg.sampleunitref, " \
+                        "c.sampleunittype, c.caseref, SUM(CASE WHEN ce.categoryFK = 'RESPONDENT_ENROLED' " \
+                        "THEN 1 ELSE  0 END) respondent_enrolled, " \
+                        "MAX(CASE WHEN ce.categoryFK = 'COLLECTION_INSTRUMENT_DOWNLOADED' " \
+                        "THEN 1 ELSE  0 END) collection_instrument_downloaded_ind, " \
+                        "MAX(CASE WHEN ce.categoryFK = 'SUCCESSFUL_RESPONSE_UPLOAD' " \
+                        "THEN 1 ELSE  0 END) successful_response_upload_ind " \
+                        "FROM casesvc.caseevent ce " \
+                        "RIGHT OUTER JOIN casesvc.case c  ON c.casePK = ce.caseFK " \
+                        "INNER JOIN casesvc.casegroup cg  ON c.casegroupFK = cg.casegroupPK " \
+                        "GROUP BY cg.sampleunitref, c.sampleunittype, c.casePK) events) as data_records " \
+                        "WHERE case_ref IN (SELECT t.caseref FROM casesvc.\"case\" t " \
+                        "WHERE t.casegroupid IN (SELECT t.id \"Group ID\" FROM casesvc.casegroup t " \
+                        f"WHERE t.collectionexerciseid='{collection_exercise_id}'))"
+
+        collex_details = engine.execute(text(collex_status)).first()
+        collex_dict = {}
+        collex_dict['sampleSize'] = collex_details[0]
+        collex_dict['accountsCreated'] = int(collex_details[1] or 0)
+        collex_dict['downloads'] = collex_details[2]
+        collex_dict['uploads'] = collex_details[3]
+
+        response = {'metadata':
+                        {'timeUpdated': datetime.now().timestamp(),
+                         'collectionExerciseId': collection_exercise_id}
+                    }
+
+        response['report'] = collex_dict
+        # details = {}
+        # for row in collex_details:
+        #     test = dict(row)
+        #
+        # for key, value in test.items():
+        #     details[key] = int(value)
+
+        return Response(json.dumps(response), content_type='application/json')

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -12,7 +12,7 @@ from rm_reporting.common.validators import parse_uuid
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@response_dashboard_api.route('/<collection_exercise_id>')
+@response_dashboard_api.route('collection_exercise/<collection_exercise_id>')
 class ResponseDashboard(Resource):
     @staticmethod
     def get(collection_exercise_id):

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -4,6 +4,7 @@ import logging
 from flask import json, Response
 from flask_restplus import Resource
 from sqlalchemy import text
+from sqlalchemy.exc import DataError
 from structlog import wrap_logger
 
 from rm_reporting import app, response_dashboard_api
@@ -13,55 +14,71 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 @response_dashboard_api.route('/<collection_exercise_id>')
 class ResponseDashboard(Resource):
-
     @staticmethod
     def get(collection_exercise_id):
 
         engine = app.db.engine
 
-        collex_status = "SELECT COUNT(DISTINCT(sample_unit_ref)) \"Sample Size\", " \
-                        "SUM(enrolled) \"Total Enrolled\", SUM(downloaded) \"Total Downloaded\", " \
-                        "SUM(uploaded) \"Total Uploaded\" " \
-                        "FROM " \
-                        "(SELECT " \
-                        "events.sampleunitref sample_unit_ref, " \
-                        "events.sampleunittype, " \
-                        "events.caseref case_ref, " \
-                        "events.respondent_enrolled enrolled, " \
-                        "events.collection_instrument_downloaded_ind downloaded, " \
-                        "events.successful_response_upload_ind uploaded " \
-                        "FROM " \
-                        "(SELECT cg.sampleunitref, " \
-                        "c.sampleunittype, c.caseref, " \
-                        "SUM(CASE WHEN ce.categoryFK = 'RESPONDENT_ENROLED' " \
-                        "THEN 1 ELSE  0 END) respondent_enrolled, " \
-                        "MAX(CASE WHEN ce.categoryFK = 'COLLECTION_INSTRUMENT_DOWNLOADED' " \
-                        "THEN 1 ELSE  0 END) collection_instrument_downloaded_ind, " \
-                        "MAX(CASE WHEN ce.categoryFK = 'SUCCESSFUL_RESPONSE_UPLOAD' " \
-                        "THEN 1 ELSE  0 END) successful_response_upload_ind " \
-                        "FROM casesvc.caseevent ce " \
-                        "RIGHT OUTER JOIN casesvc.case c  ON c.casePK = ce.caseFK " \
-                        "INNER JOIN casesvc.casegroup cg  ON c.casegroupFK = cg.casegroupPK " \
-                        "GROUP BY cg.sampleunitref, c.sampleunittype, c.casePK) events) as data_records " \
-                        "WHERE case_ref IN " \
-                        "(SELECT t.caseref FROM casesvc.\"case\" t " \
-                        "WHERE t.casegroupid IN " \
-                        "(SELECT t.id \"Group ID\" FROM casesvc.casegroup t " \
-                        "WHERE t.collectionexerciseid = :collection_exercise_id))"
+        report_query = text(
+            'SELECT '
+            'COUNT(DISTINCT(sample_unit_ref)) "Sample Size", '
+            'SUM(enrolled) "Total Enrolled", '
+            'SUM(downloaded) "Total Downloaded", '
+            'SUM(uploaded) "Total Uploaded" '
+            'FROM '
+            '(SELECT '
+            'events.sampleunitref sample_unit_ref, '
+            'events.sampleunittype, '
+            'events.caseref case_ref, '
+            'events.respondent_enrolled enrolled, '
+            'events.collection_instrument_downloaded_ind downloaded, '
+            'events.successful_response_upload_ind uploaded '
+            'FROM '
+            '(SELECT cg.sampleunitref, '
+            'c.sampleunittype, c.caseref, '
+            'SUM(CASE WHEN ce.categoryFK = \'RESPONDENT_ENROLED\' '
+            'THEN 1 ELSE  0 END) respondent_enrolled, '
+            'MAX(CASE WHEN ce.categoryFK = \'COLLECTION_INSTRUMENT_DOWNLOADED\' '
+            'THEN 1 ELSE  0 END) collection_instrument_downloaded_ind, '
+            'MAX(CASE WHEN ce.categoryFK = \'SUCCESSFUL_RESPONSE_UPLOAD\' '
+            'THEN 1 ELSE  0 END) successful_response_upload_ind '
+            'FROM casesvc.caseevent ce '
+            'RIGHT OUTER JOIN casesvc.case c ON c.casePK = ce.caseFK '
+            'INNER JOIN casesvc.casegroup cg ON c.casegroupFK = cg.casegroupPK '
+            'GROUP BY cg.sampleunitref, c.sampleunittype, c.casePK) events) as data_records '
+            'WHERE case_ref IN '
+            '(SELECT t.caseref FROM casesvc."case" t '
+            'WHERE t.casegroupid IN '
+            '(SELECT t.id "Group ID" FROM casesvc.casegroup t '
+            'WHERE t.collectionexerciseid = :collection_exercise_id))')
 
-        collex_details = engine.execute(text(collex_status), collection_exercise_id=collection_exercise_id).first()
+        try:
+            report_details = engine.execute(
+                report_query,
+                collection_exercise_id=collection_exercise_id).first()
+        except DataError as err:
+            logger.debug("Invalid parameter", invalid_param=err.params)
+            return Response(status=400)
 
-        collex_dict = {
-            'sampleSize': collex_details['Sample Size'],
-            'accountsEnrolled': int(collex_details['Total Enrolled'] or 0),
-            'downloads': collex_details['Total Downloaded'],
-            'uploads': collex_details['Total Uploaded']
+        nulls_returned = any(column is None for column in report_details)
+        if nulls_returned:
+            logger.debug(
+                "Invalid collection exercise ID",
+                collection_exercise_id=collection_exercise_id)
+            return Response(status=400)
+
+        response_content = {
+            'metadata': {
+                'timeUpdated': datetime.now().timestamp(),
+                'collectionExerciseId': collection_exercise_id
+            },
+            'report': {
+                'sampleSize': report_details['Sample Size'],
+                'accountsEnrolled': int(report_details['Total Enrolled']),
+                'downloads': report_details['Total Downloaded'],
+                'uploads': report_details['Total Uploaded']
+            }
         }
 
-        response = {
-            'metadata': {'timeUpdated': datetime.now().timestamp(),
-                         'collectionExerciseId': collection_exercise_id},
-            'report': collex_dict
-        }
-
-        return Response(json.dumps(response), content_type='application/json')
+        return Response(
+            json.dumps(response_content), content_type='application/json')

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -43,7 +43,7 @@ class ResponseDashboard(Resource):
 
         collex_details = engine.execute(text(collex_status)).first()
         collex_dict = {'sampleSize': collex_details[0],
-                       'accountsCreated': int(collex_details[1] or 0),
+                       'accountsEnrolled': int(collex_details[1] or 0),
                        'downloads': collex_details[2],
                        'uploads': collex_details[3]
                        }

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -12,7 +12,7 @@ from rm_reporting.common.validators import parse_uuid
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@response_dashboard_api.route('collection_exercise/<collection_exercise_id>')
+@response_dashboard_api.route('/collection_exercise/<collection_exercise_id>')
 class ResponseDashboard(Resource):
     @staticmethod
     def get(collection_exercise_id):

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -42,17 +42,15 @@ class ResponseDashboard(Resource):
                         f"WHERE t.collectionexerciseid='{collection_exercise_id}'))"
 
         collex_details = engine.execute(text(collex_status)).first()
-        collex_dict = {}
-        collex_dict['sampleSize'] = collex_details[0]
-        collex_dict['accountsCreated'] = int(collex_details[1] or 0)
-        collex_dict['downloads'] = collex_details[2]
-        collex_dict['uploads'] = collex_details[3]
+        collex_dict = {'sampleSize': collex_details[0],
+                       'accountsCreated': int(collex_details[1] or 0),
+                       'downloads': collex_details[2],
+                       'uploads': collex_details[3]
+                       }
 
-        response = {'metadata':
-                        {'timeUpdated': datetime.now().timestamp(),
-                         'collectionExerciseId': collection_exercise_id}
+        response = {'metadata': {'timeUpdated': datetime.now().timestamp(),
+                                 'collectionExerciseId': collection_exercise_id},
+                    'report': collex_dict
                     }
-
-        response['report'] = collex_dict
 
         return Response(json.dumps(response), content_type='application/json')

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -24,10 +24,16 @@ class ResponseDashboard(Resource):
                         "SUM(uploaded) \"Total Uploaded\" " \
                         "FROM " \
                         "(SELECT " \
-                        "events.sampleunitref sample_unit_ref, events.sampleunittype, events.caseref case_ref, " \
-                        "events.respondent_enrolled enrolled, events.collection_instrument_downloaded_ind downloaded, " \
-                        "events.successful_response_upload_ind uploaded FROM (SELECT cg.sampleunitref, " \
-                        "c.sampleunittype, c.caseref, SUM(CASE WHEN ce.categoryFK = 'RESPONDENT_ENROLED' " \
+                        "events.sampleunitref sample_unit_ref, " \
+                        "events.sampleunittype, " \
+                        "events.caseref case_ref, " \
+                        "events.respondent_enrolled enrolled, " \
+                        "events.collection_instrument_downloaded_ind downloaded, " \
+                        "events.successful_response_upload_ind uploaded " \
+                        "FROM " \
+                        "(SELECT cg.sampleunitref, " \
+                        "c.sampleunittype, c.caseref, " \
+                        "SUM(CASE WHEN ce.categoryFK = 'RESPONDENT_ENROLED' " \
                         "THEN 1 ELSE  0 END) respondent_enrolled, " \
                         "MAX(CASE WHEN ce.categoryFK = 'COLLECTION_INSTRUMENT_DOWNLOADED' " \
                         "THEN 1 ELSE  0 END) collection_instrument_downloaded_ind, " \
@@ -37,11 +43,14 @@ class ResponseDashboard(Resource):
                         "RIGHT OUTER JOIN casesvc.case c  ON c.casePK = ce.caseFK " \
                         "INNER JOIN casesvc.casegroup cg  ON c.casegroupFK = cg.casegroupPK " \
                         "GROUP BY cg.sampleunitref, c.sampleunittype, c.casePK) events) as data_records " \
-                        "WHERE case_ref IN (SELECT t.caseref FROM casesvc.\"case\" t " \
-                        "WHERE t.casegroupid IN (SELECT t.id \"Group ID\" FROM casesvc.casegroup t " \
-                        f"WHERE t.collectionexerciseid='{collection_exercise_id}'))"
+                        "WHERE case_ref IN " \
+                        "(SELECT t.caseref FROM casesvc.\"case\" t " \
+                        "WHERE t.casegroupid IN " \
+                        "(SELECT t.id \"Group ID\" FROM casesvc.casegroup t " \
+                        "WHERE t.collectionexerciseid = :collection_exercise_id))"
 
-        collex_details = engine.execute(text(collex_status)).first()
+        collex_details = engine.execute(text(collex_status), collection_exercise_id=collection_exercise_id).first()
+
         collex_dict = {'sampleSize': collex_details[0],
                        'accountsEnrolled': int(collex_details[1] or 0),
                        'downloads': collex_details[2],

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -54,11 +54,5 @@ class ResponseDashboard(Resource):
                     }
 
         response['report'] = collex_dict
-        # details = {}
-        # for row in collex_details:
-        #     test = dict(row)
-        #
-        # for key, value in test.items():
-        #     details[key] = int(value)
 
         return Response(json.dumps(response), content_type='application/json')

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -53,8 +53,7 @@ class ResponseDashboard(Resource):
                             '(SELECT t.id "Group ID" FROM casesvc.casegroup t '
                             'WHERE t.collectionexerciseid = :collection_exercise_id))')
 
-        valid_uuid = is_valid_uuid(collection_exercise_id)
-        if not valid_uuid:
+        if not is_valid_uuid(collection_exercise_id):
             logger.debug("Malformed collection exercise ID", invalid_id=collection_exercise_id)
             abort(400, "Malformed collection exercise ID")
 

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -51,15 +51,17 @@ class ResponseDashboard(Resource):
 
         collex_details = engine.execute(text(collex_status), collection_exercise_id=collection_exercise_id).first()
 
-        collex_dict = {'sampleSize': collex_details[0],
-                       'accountsEnrolled': int(collex_details[1] or 0),
-                       'downloads': collex_details[2],
-                       'uploads': collex_details[3]
-                       }
+        collex_dict = {
+            'sampleSize': collex_details['Sample Size'],
+            'accountsEnrolled': int(collex_details['Total Enrolled'] or 0),
+            'downloads': collex_details['Total Downloaded'],
+            'uploads': collex_details['Total Uploaded']
+        }
 
-        response = {'metadata': {'timeUpdated': datetime.now().timestamp(),
-                                 'collectionExerciseId': collection_exercise_id},
-                    'report': collex_dict
-                    }
+        response = {
+            'metadata': {'timeUpdated': datetime.now().timestamp(),
+                         'collectionExerciseId': collection_exercise_id},
+            'report': collex_dict
+        }
 
         return Response(json.dumps(response), content_type='application/json')

--- a/test/common/test_validators.py
+++ b/test/common/test_validators.py
@@ -1,13 +1,14 @@
 from unittest import TestCase
 
-from rm_reporting.common.validators import is_valid_uuid
+from rm_reporting.common.validators import parse_uuid
 
 
 class TestValidators(TestCase):
 
     def test_valid_uuid(self):
-        self.assertTrue(is_valid_uuid('00000000-0000-00000000-000000000000'))
+        collex_id = parse_uuid('00000000-0000-00000000-000000000000')
+        self.assertTrue(collex_id)
 
     def test_malformed_uuid(self):
-        self.assertFalse(is_valid_uuid('00000000-0000-00000000-000000000000-'))
-        self.assertFalse(is_valid_uuid('this-is-not-a-valid-uuid'))
+        collex_id = parse_uuid('this-is-not-a-valid-uuid')
+        self.assertFalse(collex_id)

--- a/test/common/test_validators.py
+++ b/test/common/test_validators.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from rm_reporting.common.validators import is_valid_uuid
+
+
+class TestValidators(TestCase):
+
+    def test_valid_uuid(self):
+        self.assertTrue(is_valid_uuid('00000000-0000-00000000-000000000000'))
+
+    def test_malformed_uuid(self):
+        self.assertFalse(is_valid_uuid('00000000-0000-00000000-000000000000-'))
+        self.assertFalse(is_valid_uuid('this-is-not-a-valid-uuid'))

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -1,11 +1,10 @@
 import json
-import unittest
-from unittest import mock
+from unittest import TestCase, mock
 
 from rm_reporting import app
 
 
-class TestResponseDashboard(unittest.TestCase):
+class TestResponseDashboard(TestCase):
 
     def setUp(self):
 

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -33,12 +33,14 @@ class TestResponseDashboard(unittest.TestCase):
     def test_dashboard_report_invalid_id(self, mock_engine):
         mock_engine.execute.return_value.first.return_value = (0, 0, 0, None)
         response = self.test_client.get('/reporting-api/v1/response-dashboard/00000000-0000-0000-0000-000000000000')
+        error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data, b'{"message": "Invalid collection exercise ID"}\n')
+        self.assertEqual(error_response, 'Invalid collection exercise ID')
 
     def test_dashboard_report_malformed_id(self):
         response = self.test_client.get('/reporting-api/v1/response-dashboard/not-a-valid-uuid-format')
+        error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.data, b'{"message": "Malformed collection exercise ID"}\n')
+        self.assertEqual(error_response, 'Malformed collection exercise ID')

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -7,26 +7,38 @@ from rm_reporting import app
 
 class TestResponseDashboard(unittest.TestCase):
 
-    report_details = {
-        'Sample Size': 100,
-        'Total Enrolled': 50,
-        'Total Downloaded': 30,
-        'Total Uploaded': 10
-    }
-
     def setUp(self):
+
         self.test_client = app.test_client()
 
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_report_success(self, mock_engine):
-        mock_engine.execute.return_value.first.return_value = self.report_details
+        valid_response = {
+            'Sample Size': 100,
+            'Total Enrolled': 50,
+            'Total Downloaded': 30,
+            'Total Uploaded': 10
+        }
+
+        mock_engine.execute.return_value.first.return_value = valid_response
         response = self.test_client.get('/reporting-api/v1/response-dashboard/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
         response_dict = json.loads(response.data)
+
         self.assertEqual(100, response_dict['report']['sampleSize'])
         self.assertEqual(50, response_dict['report']['accountsEnrolled'])
         self.assertEqual(30, response_dict['report']['downloads'])
         self.assertEqual(10, response_dict['report']['uploads'])
 
-    def test_dashboard_report_invalid_id(self):
-        response = self.test_client.get('/reporting-api/v1/response-dashboard/not_a_valid_id')
+    @mock.patch('rm_reporting.app.db.engine')
+    def test_dashboard_report_invalid_id(self, mock_engine):
+        mock_engine.execute.return_value.first.return_value = (0, 0, 0, None)
+        response = self.test_client.get('/reporting-api/v1/response-dashboard/00000000-0000-0000-0000-000000000000')
+
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, b'{"message": "Invalid collection exercise ID"}\n')
+
+    def test_dashboard_report_malformed_id(self):
+        response = self.test_client.get('/reporting-api/v1/response-dashboard/not-a-valid-uuid-format')
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, b'{"message": "Malformed collection exercise ID"}\n')

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -20,7 +20,8 @@ class TestResponseDashboard(TestCase):
         }
 
         mock_engine.execute.return_value.first.return_value = valid_response
-        response = self.test_client.get('/reporting-api/v1/response-dashboard/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
+        response = self.test_client.get(
+            '/reporting-api/v1/response-dashboard/collection_exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
         response_dict = json.loads(response.data)
 
         self.assertEqual(100, response_dict['report']['sampleSize'])
@@ -31,14 +32,16 @@ class TestResponseDashboard(TestCase):
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_report_invalid_id(self, mock_engine):
         mock_engine.execute.return_value.first.return_value = (0, 0, 0, None)
-        response = self.test_client.get('/reporting-api/v1/response-dashboard/00000000-0000-0000-0000-000000000000')
+        response = self.test_client.get(
+            '/reporting-api/v1/response-dashboard/collection_exercise/00000000-0000-0000-0000-000000000000')
         error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(error_response, 'Invalid collection exercise ID')
 
     def test_dashboard_report_malformed_id(self):
-        response = self.test_client.get('/reporting-api/v1/response-dashboard/not-a-valid-uuid-format')
+        response = self.test_client.get(
+            '/reporting-api/v1/response-dashboard/collection_exercise/not-a-valid-uuid-format')
         error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
### What is the context of this PR?
Adds a new end point for the [responses dashboard](https://github.com/ONSdigital/sdc-responses-dashboard).

You can run `ras-rm-docker-dev` locally to get a valid collection exercise id for a live `SEFT` survey. Run acceptance tests to set up this data.

Use the following query to get the above for a `BRICKS` survey.
```
SELECT id, "name", periodstartdatetime, statefk, samplesize, exerciseref, user_description, created, updated, deleted, survey_uuid
FROM collectionexercise.collectionexercise
where collectionexercise."name" like 'Monthly Survey of%'
and collectionexercise.collectionexercise.statefk = 'READY_FOR_LIVE'
```

### How to review 
1. Ensure a valid response is returned for a valid collection exercise id.
2. Ensure a 400 error is returned for an invalid or malformed collection exercise id.
3. Also check unit tests are sufficient.
