### PR TITLE
Updating responses dashboard queries

### DIFF
--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -11,14 +11,14 @@ class TestResponseDashboard(TestCase):
 
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_SEFT_report_success(self, mock_engine):
-        valid_response = {
+        mock_engine.execute.return_value.first.return_value = {
             'Sample Size': 100,
             'Total Enrolled': 50,
-            'Total Downloaded': 30,
-            'Total Uploaded': 10
+            'Total Pending': 10,
+            'Not Started': 70,
+            'In Progress': 20,
+            'Complete': 10
         }
-
-        mock_engine.execute.return_value.first.return_value = valid_response
         response = self.test_client.get(
             '/reporting-api/v1/response-dashboard/SEFT/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
         response_dict = json.loads(response.data)
@@ -30,7 +30,14 @@ class TestResponseDashboard(TestCase):
 
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_SEFT_report_invalid_id(self, mock_engine):
-        mock_engine.execute.return_value.first.return_value = (0, 0, 0, None)
+        mock_engine.execute.return_value.first.return_value = {
+            'Sample Size': 100,
+            'Total Enrolled': 50,
+            'Total Pending': 10,
+            'Not Started': 100,
+            'In Progress': 30,
+            'Complete': None
+        }
         response = self.test_client.get(
             '/reporting-api/v1/response-dashboard/SEFT/collection-exercise/00000000-0000-0000-0000-000000000000')
         error_response = json.loads(response.data)['message']
@@ -48,30 +55,36 @@ class TestResponseDashboard(TestCase):
 
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_EQ_report_success(self, mock_engine):
-        valid_response = {
-            'Total Launched': 30,
-            'Total Accounts Created': 30,
-            'Total Enrolled': 22,
-            'Total Completed': 20,
-            'Sample Size': 38
+        mock_engine.execute.return_value.first.return_value = {
+            'Sample Size': 100,
+            'Total Enrolled': 50,
+            'Total Pending': 10,
+            'Not Started': 70,
+            'In Progress': 20,
+            'Complete': 10
         }
-
-        mock_engine.execute.return_value.first.return_value = valid_response
         response = self.test_client.get(
             '/reporting-api/v1/response-dashboard/EQ/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
         response_dict = json.loads(response.data)
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(38, response_dict['report']['sampleSize'])
-        self.assertEqual(22, response_dict['report']['accountsEnrolled'])
-        self.assertEqual(30, response_dict['report']['accountsCreated'])
-        self.assertEqual(20, response_dict['report']['completed'])
-        self.assertEqual(10, response_dict['report']['inProgress'])
-        self.assertEqual(8, response_dict['report']['notStarted'])
+        self.assertEqual(100, response_dict['report']['sampleSize'])
+        self.assertEqual(50, response_dict['report']['accountsEnrolled'])
+        self.assertEqual(10, response_dict['report']['accountsPending'])
+        self.assertEqual(10, response_dict['report']['completed'])
+        self.assertEqual(20, response_dict['report']['inProgress'])
+        self.assertEqual(70, response_dict['report']['notStarted'])
 
     @mock.patch('rm_reporting.app.db.engine')
     def test_dashboard_EQ_report_invalid_id(self, mock_engine):
-        mock_engine.execute.return_value.first.return_value = (0, 0, 0, None)
+        mock_engine.execute.return_value.first.return_value = {
+            'Sample Size': 100,
+            'Total Enrolled': 50,
+            'Total Pending': 10,
+            'Not Started': 100,
+            'In Progress': 30,
+            'Complete': None
+        }
         response = self.test_client.get(
             '/reporting-api/v1/response-dashboard/EQ/collection-exercise/00000000-0000-0000-0000-000000000000')
         error_response = json.loads(response.data)['message']


### PR DESCRIPTION
# Motivation and Context
With the B/Bi changes that have occurred, the responses dashboard query needed to be changed to get account enrolled and account pending to work with the query.

# What has changed
- Responses dashboard SEFT and eQ queries have been altered
- Rename 'accounts created' to 'accounts pending'

# How to test
- Clone  the [sdc-reponses-dashboard](https://github.com/ONSdigital/sdc-responses-dashboard) repo and run on this change branch https://github.com/ONSdigital/sdc-responses-dashboard/pull/48 with rm-reporting on this PR's branch.
- For a SEFT survey and collection exercise, create a respondent and verify the account. The `Accounts Enrolled`  figure should increase for that collection exercise.
- For a eQ survey and collection exercise, when creating a respondent the `Accounts Created` figure should increase. Once the account has been verified, the `Accounts Enrolled` figure should increase and `Accounts Created` should decrease.

# Links
Trello: https://trello.com/c/m2WueDTM/78-investigating-how-to-fix-the-query-based-on-the-recent-bi-case-changes
PR on responses-dashboard: https://github.com/ONSdigital/sdc-responses-dashboard/pull/48