### PR TITLE
Responses Dashboard Report Fixes

### DIFF
--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -28,7 +28,8 @@ def get_case_report_figures(collection_exercise_id, engine):
                       'ELSE NULL '
                       'END) AS "Complete" '
                       'FROM casesvc.casegroup '
-                      'WHERE collectionexerciseid = :collection_exercise_id')
+                      'WHERE collectionexerciseid = :collection_exercise_id '
+                      'AND sampleunitref NOT LIKE \'1111%\'')
 
     return engine.execute(case_query, collection_exercise_id=collection_exercise_id).first()
 
@@ -39,7 +40,10 @@ def get_party_report(collection_exercise_id, engine):
                        'FROM partysvc.enrolment enrolment '
                        'INNER JOIN partysvc.business_attributes business_attributes '
                        'ON business_attributes.business_id = enrolment.business_id '
-                       'WHERE business_attributes.collection_exercise = :collection_exercise_id')
+                       'INNER JOIN samplesvc.sampleunit sample_unit '
+                       'ON sample_unit.id::text = business_attributes.attributes->> \'sampleUnitId\' '
+                       'WHERE business_attributes.collection_exercise = :collection_exercise_id '
+                       'and sample_unit.sampleunitref not like \'1111%\'')
 
     return engine.execute(party_query, collection_exercise_id=collection_exercise_id).first()
 

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -82,6 +82,11 @@ class ResponseDashboard(Resource):
 
         engine = app.db.engine
 
+        survey_id = parse_uuid(survey_id)
+        if not survey_id:
+            logger.debug('Malformed survey ID', invalid_id=survey_id)
+            abort(400, 'Malformed survey ID')
+
         collection_exercise_id = parse_uuid(collection_exercise_id)
         if not collection_exercise_id:
             logger.debug('Malformed collection exercise ID', invalid_id=collection_exercise_id)
@@ -89,10 +94,8 @@ class ResponseDashboard(Resource):
 
         try:
             report = get_report(survey_id, collection_exercise_id, engine)
-        except KeyError:
-            abort(404, 'Invalid collection instrument type')
         except NoDataException:
-            abort(404, 'Invalid collection exercise ID')
+            abort(404, 'Invalid collection exercise or survey ID')
 
         response = {
             'metadata': {

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -42,8 +42,8 @@ def get_party_report(survey_id, collection_exercise_id, engine):
                        'ON business_attributes.business_id = enrolment.business_id '
                        'INNER JOIN samplesvc.sampleunit sample_unit '
                        'ON sample_unit.id::text = business_attributes.attributes->> \'sampleUnitId\' '
-                       'WHERE business_attributes.collection_exercise = :collection_exercise_id '
-                       'AND enrolment.survey_id = :survey_id '
+                       'WHERE enrolment.survey_id = :survey_id '
+                       'AND business_attributes.collection_exercise = :collection_exercise_id '
                        'AND sample_unit.sampleunitref NOT LIKE \'1111%\'')
 
     return engine.execute(party_query,

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -48,9 +48,9 @@ class TestResponseDashboard(TestCase):
         error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(error_response, 'Invalid collection exercise ID')
+        self.assertEqual(error_response, 'Invalid collection exercise or survey ID')
 
-    def test_dashboard_report_malformed_id(self):
+    def test_dashboard_report_malformed_collection_exercise_id(self):
         response = self.test_client.get(
             '/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129'
             '/collection-exercise/not-a-valid-uuid-format')
@@ -58,3 +58,12 @@ class TestResponseDashboard(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(error_response, 'Malformed collection exercise ID')
+
+    def test_dashboard_report_malformed_survey_id(self):
+        response = self.test_client.get(
+            '/reporting-api/v1/response-dashboard/survey/not-a-valid-uuid-format'
+            '/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
+        error_response = json.loads(response.data)['message']
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(error_response, 'Malformed survey ID')

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -10,7 +10,7 @@ class TestResponseDashboard(TestCase):
         self.test_client = app.test_client()
 
     @mock.patch('rm_reporting.app.db.engine')
-    def test_dashboard_SEFT_report_success(self, mock_engine):
+    def test_dashboard_report_success(self, mock_engine):
         mock_engine.execute.return_value.first.return_value = {
             'Sample Size': 100,
             'Total Enrolled': 50,
@@ -20,51 +20,8 @@ class TestResponseDashboard(TestCase):
             'Complete': 10
         }
         response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/SEFT/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
-        response_dict = json.loads(response.data)
-
-        self.assertEqual(100, response_dict['report']['sampleSize'])
-        self.assertEqual(50, response_dict['report']['accountsEnrolled'])
-        self.assertEqual(30, response_dict['report']['downloads'])
-        self.assertEqual(10, response_dict['report']['uploads'])
-
-    @mock.patch('rm_reporting.app.db.engine')
-    def test_dashboard_SEFT_report_invalid_id(self, mock_engine):
-        mock_engine.execute.return_value.first.return_value = {
-            'Sample Size': 100,
-            'Total Enrolled': 50,
-            'Total Pending': 10,
-            'Not Started': 100,
-            'In Progress': 30,
-            'Complete': None
-        }
-        response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/SEFT/collection-exercise/00000000-0000-0000-0000-000000000000')
-        error_response = json.loads(response.data)['message']
-
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(error_response, 'Invalid collection exercise ID')
-
-    def test_dashboard_SEFT_report_malformed_id(self):
-        response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/SEFT/collection-exercise/not-a-valid-uuid-format')
-        error_response = json.loads(response.data)['message']
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(error_response, 'Malformed collection exercise ID')
-
-    @mock.patch('rm_reporting.app.db.engine')
-    def test_dashboard_EQ_report_success(self, mock_engine):
-        mock_engine.execute.return_value.first.return_value = {
-            'Sample Size': 100,
-            'Total Enrolled': 50,
-            'Total Pending': 10,
-            'Not Started': 70,
-            'In Progress': 20,
-            'Complete': 10
-        }
-        response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/EQ/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
+            '/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+            '/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3')
         response_dict = json.loads(response.data)
 
         self.assertEqual(200, response.status_code)
@@ -76,7 +33,7 @@ class TestResponseDashboard(TestCase):
         self.assertEqual(70, response_dict['report']['notStarted'])
 
     @mock.patch('rm_reporting.app.db.engine')
-    def test_dashboard_EQ_report_invalid_id(self, mock_engine):
+    def test_dashboard_report_invalid_id(self, mock_engine):
         mock_engine.execute.return_value.first.return_value = {
             'Sample Size': 100,
             'Total Enrolled': 50,
@@ -86,23 +43,18 @@ class TestResponseDashboard(TestCase):
             'Complete': None
         }
         response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/EQ/collection-exercise/00000000-0000-0000-0000-000000000000')
+            '/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+            '/collection-exercise/00000000-0000-0000-0000-000000000000')
         error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(error_response, 'Invalid collection exercise ID')
 
-    def test_dashboard_EQ_report_malformed_id(self):
+    def test_dashboard_report_malformed_id(self):
         response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/EQ/collection-exercise/not-a-valid-uuid-format')
+            '/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129'
+            '/collection-exercise/not-a-valid-uuid-format')
         error_response = json.loads(response.data)['message']
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(error_response, 'Malformed collection exercise ID')
-
-    def test_invalid_collection_instrument_type_returns_404(self):
-        response = self.test_client.get(
-            '/reporting-api/v1/response-dashboard/NOT_VALID/collection-exercise/00000000-0000-0000-0000-000000000000')
-
-        self.assertEqual(404, response.status_code)
-        self.assertEqual('Invalid collection instrument type', json.loads(response.data)['message'])


### PR DESCRIPTION
#### Context
Fixes multiple issues with the responses dashboard endpoint. The enrolment count was showing inflated numbers as it was counting businesses that are enrolled in multiple different surveys multiple times. Also the dashboard was counting all sample units including dummies for testing.

#### What Has Changed
- Refactor two dashboard figure queries into single query using WITH
- Filter by survey ID in the party svc tables for an accurate count per collex
- Add survey ID to endpoint url
- Remove collection instrument type conditions and url param, no longer required
- Filter by sampleunitref to exclude dummy sampleunitrefs from count
- Update tests

#### How to Test
Run with this branch of sdc-responses-dashboard https://github.com/ONSdigital/sdc-responses-dashboard/pull/54. The dashboard should still function correctly and now report the correct enrolment numbers even when businesses are enrolled in multiple different surveys

#### Links
https://trello.com/c/kp7foNVs/87-bug-accounts-enrolled-and-pending-counts-dont-filter-by-survey-id
https://trello.com/c/Kl95brGU/88-dont-count-dummy-sample-units
https://github.com/ONSdigital/sdc-responses-dashboard/pull/54
 