### PR TITLE
Changed query to avoid unitrefs starting with 1111

### DIFF
--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -22,7 +22,7 @@ def get_report_figures(survey_id, collection_exercise_id, engine):
         'COUNT(CASE WHEN status = \'COMPLETE\' THEN 1 ELSE NULL END) AS "Complete" '
         'FROM casesvc.casegroup '
         'WHERE collectionexerciseid = :collection_exercise_id '
-        'AND sampleunitref NOT LIKE \'1%\'), '
+        'AND sampleunitref NOT LIKE \'1111%\'), '
         'survey_enrolments AS '
         '(SELECT e.business_id, e.status '
         'FROM partysvc.enrolment e '
@@ -34,7 +34,7 @@ def get_report_figures(survey_id, collection_exercise_id, engine):
         'COUNT(CASE WHEN survey_enrolments.status = \'PENDING\' THEN 1 ELSE NULL END) AS "Total Pending" '
         'FROM survey_enrolments '
         'INNER JOIN partysvc.business b ON survey_enrolments.business_id = b.party_uuid '
-        'WHERE b.business_ref NOT LIKE \'1%\') '
+        'WHERE b.business_ref NOT LIKE \'1111%\') '
         'SELECT * FROM case_figures, party_figures'
     )
 


### PR DESCRIPTION
In production, the sample files for ASHE are different to other sample files because they start with `14` instead of the usual `49` or `50`. The query for getting the dashboard avoids dummy samples starting with `1` so we've accidentally been avoiding ASHE samples for a while now. This PR changes the query to avoid `1111` instead of `1`.

## To Test
- Run the unit tests
- Load in a sample file with samples that starts with `1`. The dashboard should still show those figures. 