### PR TITLE
added generated helm templates

### DIFF
--- a/_infra/helm/.helmignore
+++ b/_infra/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/_infra/helm/Chart.yaml
+++ b/_infra/helm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: rm-reporting
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 11.0.0

--- a/_infra/helm/Chart.yaml
+++ b/_infra/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: rm-reporting
+name: reporting
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -18,4 +18,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 11.0.0
+appVersion: 2.0.0

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "eu.gcr.io/ons-rasrmbs-management/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "eu.gcr.io/ons-rasrmbs-management/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           ports:
             - name: http-server

--- a/_infra/helm/templates/deployment.yaml
+++ b/_infra/helm/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge:
+      maxUnavailable:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: (( .Chart.Name }}
+      env: "{{ .Values.env }}"
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+        env: "{{ .Values.env }}"
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "eu.gcr.io/ons-rasrmbs-management/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http-server
+              containerPort: 8084
+          readinessProbe:
+            httpGet:
+              path: /info
+              port: 8084
+            initialDelaySeconds: 1
+            periodSeconds: 20
+            failureThreshold: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /info
+              port: 8084
+            initialDelaySeconds: 1
+            periodSeconds: 20
+            failureThreshold: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          env:
+          - name: DB_HOST
+            value: $(POSTGRES_SERVICE_HOST)
+          - name: DB_PORT
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: db-port
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: db-name
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: username
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: password
+          - name: SECURITY_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-user
+          - name: SECURITY_USER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-password
+          - name: PORT
+            value: "8084"
+          - name: DATABASE_URI
+            value: "postgres://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/postgres"
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 256Mi

--- a/_infra/helm/templates/service.yaml
+++ b/_infra/helm/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8084
+    protocol: TCP
+  selector:
+    app: {{ .Chart.Name }}

--- a/_infra/helm/values.yaml
+++ b/_infra/helm/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+env: "dev"
+version: "1.2"
+
+image:
+  tag: migration-sandbox
+  repository: eu.gcr.io/rm-ras-sandbox
+
+service:
+  port: 8084
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "256Mi"
+  limits:
+    cpu: "1000m"
+    memory: "512Mi"

--- a/_infra/helm/values.yaml
+++ b/_infra/helm/values.yaml
@@ -1,11 +1,6 @@
 replicaCount: 1
 
 env: "dev"
-version: "1.2"
-
-image:
-  tag: migration-sandbox
-  repository: eu.gcr.io/rm-ras-sandbox
 
 service:
   port: 8084


### PR DESCRIPTION
# Motivation and Context
Now that deployments via helm are possible, the helm charts needed to be move to their respective git repos.

# What has changed

- Generated templates using ras-rm-terraform for service.yaml and deployment.yaml.

- Created new folder called '_infra' in the root, and put the templates in a folder called 'helm'.

- Overwrote the .yaml files.

# How to test?
Check that the infra folder exists, and that the templates are present. They should be different from the ones in the 'rm-reporting' folder in ras-rm-terraform's root.

# Links
[Trello card](https://trello.com/c/1tzVVyz6)
