### PR TITLE
Add structlog processor for Google Cloud Logging

### DIFF
--- a/rm_reporting/logger_config.py
+++ b/rm_reporting/logger_config.py
@@ -32,7 +32,21 @@ def logger_initial_config(service_name=None,
         event_dict['service'] = service_name
         return event_dict
 
+    def add_severity_level(logger, method_name, event_dict):
+        """
+        Add the log level to the event dict.
+        """
+        if method_name == "warn":
+            # The stdlib has an alias
+            method_name = "warning"
+
+        event_dict["severity"] = method_name
+        return event_dict
+
     logging.basicConfig(stream=sys.stdout, level=log_level, format=logger_format)
-    configure(processors=[add_log_level, filter_by_level, add_service, format_exc_info,
+    configure(processors=[add_severity_level,
+                          add_log_level,
+                          filter_by_level,
+                          add_service, format_exc_info,
                           TimeStamper(fmt=logger_date_format, utc=True, key="created_at"),
                           JSONRenderer(indent=indent)])

--- a/test/test_logger_config.py
+++ b/test/test_logger_config.py
@@ -25,7 +25,7 @@ class TestLoggerConfig(unittest.TestCase):
         logger.error('Test')
         message = l.records[0].msg
 
-        message_contents = '{\n "event": "Test",\n "level": "error",\n "service": "rm-reporting"'
+        message_contents = '{\n "event": "Test",\n "severity": "error",\n "level": "error",\n "service": "rm-reporting"'
         self.assertIn(message_contents, message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
@@ -36,7 +36,7 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('{"event": "Test", "level": "error", "service": "rm-reporting"', message)
+        self.assertIn('{"event": "Test", "severity": "error", "level": "error", "service": "rm-reporting"', message)
 
     @pytest.mark.filterwarnings(f"ignore:{testfixtures_warning}")
     @log_capture()
@@ -45,4 +45,4 @@ class TestLoggerConfig(unittest.TestCase):
         logger = wrap_logger(logging.getLogger())
         logger.error('Test')
         message = l.records[0].msg
-        self.assertIn('{"event": "Test", "level": "error", "service": "rm-reporting"', message)
+        self.assertIn('{"event": "Test", "severity": "error", "level": "error", "service": "rm-reporting"', message)


### PR DESCRIPTION
# Motivation and Context
Added "severity level" processor to structlog, so Google Cloud Logging can parse severity
<!--- Why is this change required? What problem does it solve? -->

# What has changed
New structlog processor defined in logger config
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
Local: make test

dev: Spin up cluster in Dev, with pod built from image tag "cloud-logging"; generate error; check Stackdriver logs for correct parsing and severity levels
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
https://trello.com/c/wDSxYgCQ
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
