### PR TITLE
remove hardcoded db name

### DIFF
--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.6
+appVersion: 2.0.7

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -129,9 +129,9 @@ spec:
             value: "{{ .Values.container.port }}"
           - name: DATABASE_URI
             {{- if .Values.database.sqlProxyEnabled }}
-            value: "postgres://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/reporting"
+            value: "postgres://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"
             {{- else }}
-            value: "postgres://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/reporting"
+            value: "postgres://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
             {{- end }}
           resources:
             {{ toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Remove hardcoded db name from the helm chart. The name of the database is in the config.

This will fix the reporting api in dev.