### PR TITLE
use DISTINCT in response chasing query

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.16
+appVersion: 2.0.17

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -47,7 +47,7 @@ class ResponseChasingDownload(Resource):
 
         collex_status = "WITH " \
                         "business_details AS " \
-                        "(SELECT " \
+                        "(SELECT DISTINCT" \
                         "ba.collection_exercise As collection_exercise_uuid, " \
                         "b.business_ref AS sampleunitref, " \
                         "ba.business_id AS business_party_uuid, " \
@@ -73,7 +73,7 @@ class ResponseChasingDownload(Resource):
                         "LEFT JOIN partysvc.respondent r ON e.respondent_id = r.id " \
                         "WHERE " \
                         f"e.survey_id = '{survey_id}') " \
-                        "SELECT DISTINCT cd.case_status, bd.sampleunitref, bd.business_name, " \
+                        "SELECT cd.case_status, bd.sampleunitref, bd.business_name, " \
                         "rd.enrolment_status, rd.respondent_name, " \
                         "rd.telephone, rd.email_address, rd.respondent_status " \
                         "FROM " \

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -73,7 +73,7 @@ class ResponseChasingDownload(Resource):
                         "LEFT JOIN partysvc.respondent r ON e.respondent_id = r.id " \
                         "WHERE " \
                         f"e.survey_id = '{survey_id}') " \
-                        "SELECT cd.case_status, bd.sampleunitref, bd.business_name, " \
+                        "SELECT DISTINCT cd.case_status, bd.sampleunitref, bd.business_name, " \
                         "rd.enrolment_status, rd.respondent_name, " \
                         "rd.telephone, rd.email_address, rd.respondent_status " \
                         "FROM " \


### PR DESCRIPTION
For https://trello.com/c/tjksS6cW/377-ops-duplicate-entries-in-response-status-report, fix the reporting query by adding the `DISTINCT` keyword to the sub-select. 
Also added PR template, for future PRs.