### PR TITLE
Incorrect number of enrollment accounts for AITIS

### DIFF
--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.29
+appVersion: 2.0.30

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -24,7 +24,7 @@ def get_report_figures(survey_id, collection_exercise_id, engine):
         'WHERE collection_exercise_id = :collection_exercise_id '
         'AND sample_unit_ref NOT LIKE \'1111%\'), '
         'survey_enrolments AS '
-        '(SELECT e.business_id, e.status '
+        '(SELECT DISTINCT(e.business_id), e.status '
         'FROM partysvc.enrolment e '
         'INNER JOIN partysvc.business_attributes ba ON e.business_id = ba.business_id '
         'WHERE survey_id = :survey_id '


### PR DESCRIPTION
# Motivation and Context
For AITIS the total enrolment on the response dashboard is incorrect.

# What has changed
Added Distinct key word to avoid duplication of records.

# How to test?
Go to AITIS SDC dashboard and match the record with response chasing.

# Links
https://trello.com/c/ed1MNaT9/756-ritm0606637-incorrect-number-of-enrolled-accounts-displaying-on-dashboard-for-aitis