### PR TITLE
SPP - make GCS bucket upload configurable

### DIFF
--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -143,6 +143,8 @@ spec:
             value: "{{ .Values.gcp.project }}"
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/secrets/google/credentials.json
+          - name: GCS_ENABLED
+            value: "{{ .Values.gcp.bucket.enabled }}"
           - name: GCS_BUCKET_NAME
             value: "{{ .Values.gcp.bucket.name }}"
           - name: GCS_BUCKET_PREFIX

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -48,6 +48,7 @@ gcp:
   bucket:
     name: "ras-rm-spp-report-dev"
     prefix: ""
+    enabled: true
 
 aws:
   enabled: false

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ class Config(object):
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/ras")
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+    GCS_ENABLED = os.getenv("GCS_ENABLED", "false")
     GCS_BUCKET_NAME = os.getenv("GCS_BUCKET_NAME")
     GCS_BUCKET_PREFIX = os.getenv("GCS_BUCKET_PREFIX")
     S3_BUCKET = os.getenv("S3_BUCKET")

--- a/rm_reporting/resources/spp_reporting.py
+++ b/rm_reporting/resources/spp_reporting.py
@@ -182,8 +182,9 @@ def upload_spp_files(reporting_unit_respondent_information, survey_response_stat
     ccsi_file_name = "CCSI" + day + ".json"
     rci_file_name = "RCI" + day + ".json"
     gcs = GoogleCloudStorageGateway(app.config)
-    gcs.upload_spp_file_to_gcs(file_name=ccsi_file_name, file=survey_response_status)
-    gcs.upload_spp_file_to_gcs(file_name=rci_file_name, file=reporting_unit_respondent_information)
+    if app.config["GCS_ENABLED"] == "true":
+        gcs.upload_spp_file_to_gcs(file_name=ccsi_file_name, file=survey_response_status)
+        gcs.upload_spp_file_to_gcs(file_name=rci_file_name, file=reporting_unit_respondent_information)
     if app.config["AWS_ENABLED"] == "true":
         s3 = SimpleStorageServiceGateway(app.config)
         s3.upload_spp_file(file_name=ccsi_file_name, file=survey_response_status)


### PR DESCRIPTION
As requested by IA we should stop storing the SPP output in a GCS bucket 