### PR TITLE
Less awful response chasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv run flake8
 	pipenv check
 	pipenv run isort .
 	pipenv run black --line-length 120 .
+	pipenv run flake8
 
 lint-check:
-	pipenv run flake8
 	pipenv check
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 --check .
+	pipenv run flake8
 
 test: lint-check
 	pipenv run pytest --cov=rm_reporting

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.48
+version: 2.0.49
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.48
+appVersion: 2.0.49

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -135,6 +135,24 @@ spec:
                 key: security-password
           - name: PORT
             value: "{{ .Values.container.port }}"
+          - name: CASE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://case.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(CASE_SERVICE_HOST):$(CASE_SERVICE_PORT)"
+            {{- end }}
+          - name: COLLECTION_EXERCISE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://collection-exercise.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(COLLECTION_EXERCISE_SERVICE_HOST):$(COLLECTION_EXERCISE_SERVICE_PORT)"
+            {{- end }}
+          - name: PARTY_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://party.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)"
+            {{- end }}
           - name: DATABASE_URI
             {{- if .Values.database.sqlProxyEnabled }}
             value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -135,18 +135,6 @@ spec:
                 key: security-password
           - name: PORT
             value: "{{ .Values.container.port }}"
-          - name: CASE_URL
-            {{- if .Values.dns.enabled }}
-            value: "http://case.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
-            {{- else }}
-            value: "http://$(CASE_SERVICE_HOST):$(CASE_SERVICE_PORT)"
-            {{- end }}
-          - name: COLLECTION_EXERCISE_URL
-            {{- if .Values.dns.enabled }}
-            value: "http://collection-exercise.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
-            {{- else }}
-            value: "http://$(COLLECTION_EXERCISE_SERVICE_HOST):$(COLLECTION_EXERCISE_SERVICE_PORT)"
-            {{- end }}
           - name: PARTY_URL
             {{- if .Values.dns.enabled }}
             value: "http://party.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -33,7 +33,7 @@ autoscaling: false
 scaleAt:
   # These are expressed as a percentage of resources.requests, not resources.limits
   memoryPercentage: 150
-  cpuPercentage: 250
+  cpuPercentage: 150
 replicas: 1
 rollingUpdate:
   maxSurge: 1

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -46,3 +46,7 @@ database:
     usernameKey: username
     passwordKey: password
     nameKey: db-name
+
+dns:
+  enabled: false
+  wellKnownPort: 8080

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -1,4 +1,5 @@
 env: minikube
+namespace: minikube
 
 image:
   devRepo: eu.gcr.io/ons-rasrmbs-management

--- a/config.py
+++ b/config.py
@@ -13,17 +13,17 @@ class Config(object):
     DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/ras")
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    CASE_URL = os.getenv("CASE_URL")
-    COLLECTION_EXERCISE_URL = os.getenv("COLLECTION_EXERCISE_URL")
     PARTY_URL = os.getenv("PARTY_URL")
 
 
 class DevelopmentConfig(Config):
     DEBUG = True
-    LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "DEBUG")
+    LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
     SECURITY_USER_NAME = os.getenv("SECURITY_USER_NAME", "admin")
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD", "secret")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
+
+    PARTY_URL = os.getenv("PARTY_URL", "http://localhost:8081")
 
 
 class TestingConfig(DevelopmentConfig):

--- a/config.py
+++ b/config.py
@@ -18,7 +18,7 @@ class Config(object):
 
 class DevelopmentConfig(Config):
     DEBUG = True
-    LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "INFO")
+    LOGGING_LEVEL = os.getenv("LOGGING_LEVEL", "DEBUG")
     SECURITY_USER_NAME = os.getenv("SECURITY_USER_NAME", "admin")
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD", "secret")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)

--- a/config.py
+++ b/config.py
@@ -13,6 +13,10 @@ class Config(object):
     DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/ras")
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
+    CASE_URL = os.getenv("CASE_URL")
+    COLLECTION_EXERCISE_URL = os.getenv("COLLECTION_EXERCISE_URL")
+    PARTY_URL = os.getenv("PARTY_URL")
+
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -1,0 +1,65 @@
+import logging
+from urllib.parse import urlencode
+
+import requests
+from flask import current_app as app
+from structlog import wrap_logger
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_business_by_ru_ref(ru_ref: str):
+    """
+    Get business by ru_ref
+
+    :param ru_ref: The ru_ref of the business
+    :type ru_ref: str
+    :return: A dict of data about the business
+    :rtype: dict
+    :raises ApiError: Raised if party returns a 4XX or 5XX status code.
+    """
+    logger.info("Retrieving reporting unit", ru_ref=ru_ref)
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/businesses/ref/{ru_ref}'
+    response = requests.get(url, auth=app.config["BASIC_AUTH"])
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        log_level = logger.warning if response.status_code in (400, 404) else logger.exception
+        log_level("Failed to retrieve reporting unit", ru_ref=ru_ref)
+        raise
+
+    logger.info("Successfully retrieved reporting unit", ru_ref=ru_ref)
+    return response.json()
+
+
+def get_respondent_by_party_ids(uuids):
+    """
+    Gets data for multiple respondents from party.  If the list is empty, returns an empty
+    list without going to party.
+
+    This call will return as many parties as it can find.  If some are missing, no error will
+    be thrown.
+
+    :param uuids: A list of uuid strings of respondent party ids
+    :type uuids: list
+    :return: A list of dicts containing party data
+    """
+    bound_logger = logger.bind(respondent_party_ids=uuids)
+    bound_logger.info("Retrieving respondent data for multiple respondents")
+    if not uuids:
+        bound_logger.info("No party uuids provided.  Returning empty list")
+        return []
+
+    params = urlencode([("id", uuid) for uuid in uuids])
+    url = f'{app.config["PARTY_URL"]}/party-api/v1/respondents'
+    response = requests.get(url, auth=app.config["BASIC_AUTH"], params=params)
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        bound_logger.error("Error retrieving respondent data for multiple respondents")
+        raise
+
+    bound_logger.info("Successfully retrieved respondent data for multiple respondents")
+    return response.json()

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -64,16 +64,24 @@ class ResponseChasingDownload(Resource):
             respondent_party_ids = [respondent["partyId"] for respondent in reporting_unit.get("associations")]
             respondents = party_controller.get_respondent_by_party_ids(respondent_party_ids)
             if len(respondents) == 0:
-                business = [row[1], row[0], reporting_unit.get('name'), None, None, None, None, None]
+                business = [row[1], row[0], reporting_unit.get("name"), None, None, None, None, None]
                 ws.append(business)
                 continue
-            respondent = respondents[0]
 
-            ru_status = next(item for item in respondent.get('associations') if item["sampleUnitRef"] == row[0])
-            enrolment_status = next(item for item in ru_status.get('enrolments') if item["surveyId"] == survey_id)
-            business = [row[1], row[0], reporting_unit.get('name'), enrolment_status.get('enrolmentStatus'), respondent.get('firstName'),
-                        respondent.get('telephone'), respondent.get('emailAddress'), respondent.get('status')]
-            ws.append(business)
+            for respondent in respondents:
+                ru_status = next(item for item in respondent.get("associations") if item["sampleUnitRef"] == row[0])
+                enrolment_status = next(item for item in ru_status.get("enrolments") if item["surveyId"] == survey_id)
+                business = [
+                    row[1],
+                    row[0],
+                    reporting_unit.get("name"),
+                    enrolment_status.get("enrolmentStatus"),
+                    respondent.get("firstName"),
+                    respondent.get("telephone"),
+                    respondent.get("emailAddress"),
+                    respondent.get("status"),
+                ]
+                ws.append(business)
 
         wb.active = 1
         wb.save(output)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -41,6 +41,13 @@ class ResponseChasingDownload(Resource):
             ws[cell] = header
             ws.column_dimensions[cell[0]].width = len(header)
 
+        # Get cases by collection exercise id (doesn't exist somehow...)
+        # get /businesses/id/<business_id>/attributes?collection_exercise_id=collex_id
+        # These 2 get you the first 3 fields.
+        #    reporting_unit = party_controller.get_business_by_ru_ref(ru_ref)
+        # Get all respondents for the given ru
+        # respondent_party_ids = [respondent["partyId"] for respondent in reporting_unit.get("associations")]
+        # respondents = party_controller.get_respondent_by_party_ids(respondent_party_ids)
         engine = app.db.engine
 
         collex_status = (

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -69,21 +69,25 @@ class ResponseChasingDownload(Resource):
                 continue
 
             for respondent in respondents:
-                ru_status = next(item for item in respondent.get("associations") if item["sampleUnitRef"] == row[0])
-                enrolment_status = next(
-                    item for item in ru_status.get("enrolments") if item.get("surveyId") == survey_id
-                )
-                business = [
-                    row[1],
-                    row[0],
-                    reporting_unit.get("name"),
-                    enrolment_status.get("enrolmentStatus"),
-                    respondent.get("firstName"),
-                    respondent.get("telephone"),
-                    respondent.get("emailAddress"),
-                    respondent.get("status"),
-                ]
-                ws.append(business)
+                try:
+                    ru_status = next(item for item in respondent.get("associations") if item["sampleUnitRef"] == row[0])
+                    enrolment_status = next(
+                        item for item in ru_status.get("enrolments") if item.get("surveyId") == survey_id
+                    )
+                    business = [
+                        row[1],
+                        row[0],
+                        reporting_unit.get("name"),
+                        enrolment_status.get("enrolmentStatus"),
+                        respondent.get("firstName"),
+                        respondent.get("telephone"),
+                        respondent.get("emailAddress"),
+                        respondent.get("status"),
+                    ]
+                    ws.append(business)
+                except Exception:
+                    logger.error(respondent, exc_info=True)
+                    raise
 
         wb.active = 1
         wb.save(output)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -70,7 +70,9 @@ class ResponseChasingDownload(Resource):
 
             for respondent in respondents:
                 ru_status = next(item for item in respondent.get("associations") if item["sampleUnitRef"] == row[0])
-                enrolment_status = next(item for item in ru_status.get("enrolments") if item["surveyId"] == survey_id)
+                enrolment_status = next(
+                    item for item in ru_status.get("enrolments") if item.get("surveyId") == survey_id
+                )
                 business = [
                     row[1],
                     row[0],

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -76,20 +76,20 @@ class ResponseChasingDownload(Resource):
                     enrolment_status = next(
                         item for item in ru_status.get("enrolments") if item.get("surveyId") == survey_id
                     )
-                    business = [
-                        case_status,
-                        sample_unit_ref,
-                        reporting_unit.get("name"),
-                        enrolment_status.get("enrolmentStatus"),
-                        respondent.get("firstName"),
-                        respondent.get("telephone"),
-                        respondent.get("emailAddress"),
-                        respondent.get("status"),
-                    ]
-                    ws.append(business)
-                except Exception:
-                    logger.error(respondent, exc_info=True)
-                    raise
+                except StopIteration:
+                    continue
+
+                business = [
+                    case_status,
+                    sample_unit_ref,
+                    reporting_unit.get("name"),
+                    enrolment_status.get("enrolmentStatus"),
+                    respondent.get("firstName"),
+                    respondent.get("telephone"),
+                    respondent.get("emailAddress"),
+                    respondent.get("status"),
+                ]
+                ws.append(business)
 
         wb.active = 1
         wb.save(output)


### PR DESCRIPTION
# What and why?

Generating a report takes forever, doing it it this way should get a smaller amount of data from the database (hopefully in a shorter amount of time) then use api's to resolve the rest of the data.

If this works, then we could look to maybe hook this into the case database in the read-only replica and do away with the foreign data wrapper and the reporting database all-together!

EDIT:  This ended up being really bad on especially large companies.  Might need to rethink the approach, but I'll leave this PR open as a jumping off point

# How to test?

# Trello
