### PR TITLE
Fix security account key deprecation

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,17 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
+      - uses: actions/checkout@v3
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          export_default_credentials: true
-          
       - uses: onsdigital/ras-rm-spinnaker-action@main
         with:
           comment-body: ${{ github.event.comment.body }}

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -12,10 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/deploy')
     steps:
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
+        with:
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCR_KEY }}
           export_default_credentials: true
           
       - uses: onsdigital/ras-rm-spinnaker-action@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,10 +43,10 @@ jobs:
         run: |
           make test
       - name: Authenticate with Google Cloud
-        id: 'auth'
-        uses: 'google-github-actions/auth@v0'
+        id: auth
+        uses: google-github-actions/auth@v0
         with:
-          credentials_json: '${{ secrets.GCR_KEY }}'
+          credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
       - run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Test
         run: |
           make test
-      - uses: google-github-actions/setup-gcloud@v0
+      - name: Authenticate with Google Cloud
+        id: 'auth'
+        uses: 'google-github-actions/auth@v0'
         with:
-          version: '270.0.0'
-          service_account_key: ${{ secrets.GCR_KEY }}
-        # Configure docker to use the gcloud command-line tool as a credential helper
+          credentials_json: '${{ secrets.GCR_KEY }}'
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
       - run: |
           gcloud auth configure-docker
 

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.48
+version: 2.0.49
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.48
+appVersion: 2.0.49


### PR DESCRIPTION
# What and why?
This PR updates Github actions to fix "service_account_key" has been deprecate. Replacing it with google-github-actions/auth in both main.yml and comment.yml
# How to test?
For main.yml check https://github.com/ONSdigital/rm-reporting/runs/7211063933?check_suite_focus=true
For comment.yml see https://github.com/ONSdigital/response-operations-ui/pull/747 on how I tested in response-operations, as it is a virtual copy bar the service I didn't repeat it here