### PR TITLE
Use read replica for dashboard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv==2022.11.11
+          pip install pipenv
           pipenv install --dev
       - name: Test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv
+          pip install pipenv==2022.11.11
           pipenv install --dev
       - name: Test
         run: |

--- a/API.md
+++ b/API.md
@@ -14,10 +14,6 @@ GET request to this endpoint displays the name of the service and its version nu
 * `collection_exercise_id` is the ID of the collection exercise.
 * `survey_id` is the ID of the survey.
 
-`/reporting-api/v1/response-chasing/download-social-mi/<collection_exercise_id>`
-* GET request to this endpoint fetches a social MI report.
-* `collection_exercise_id` is the ID of the collection exercise.
-
 ## Responses dashboard endpoints
 
 `/reporting-api/v1/response-dashboard/survey/<survey_id>/collection-exercise/<collection_exercise_id>`

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check -i 51499
+	pipenv check
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8
 
 lint-check:
-	pipenv check -i 51499
+	pipenv check
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint-check:
 	pipenv run flake8
 
 test: lint-check
-	pipenv run pytest --cov=rm_reporting
+	pipenv run pytest --cov=rm_reporting --cov-report term-missing
 
 start:
 	pipenv run python run.py

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -33,19 +33,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:2bd7d3e8362f0e0d84fe4c3a06f1bd46fd2dbedbea76ac24e89f28439837a9e7",
-                "sha256:4943faf38979ac445627390b431b0c08a73ccd5ecd46983e1d29cee454d14aaa"
+                "sha256:0e455bc50190cec1af819c9e4a257130661c4f2fad1e211b4dd2cb8f9af89464",
+                "sha256:e2bfc955fb70053951589d01919c9233c6ef091ae1404bb5249a0f27e05b6b36"
             ],
             "index": "pypi",
-            "version": "==1.26.6"
+            "version": "==1.26.15"
         },
         "botocore": {
             "hashes": [
-                "sha256:574a9dc8b7cf1d866e6255c57af25de1f0da1babc6ce9faf05f227fd28ca905e",
-                "sha256:bb595ed6a42ff85b4d5fb7a2e31b8584b87df46933a6f830fd98f91b1feea279"
+                "sha256:02cfa6d060c50853a028b36ada96f4ddb225948bf9e7e0a4dc5b72f9e3878f15",
+                "sha256:7d4e148870c98bbaab04b0c85b4d3565fc00fec6148cab9da96ab4419dbfb941"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.29.6"
+            "version": "==1.29.15"
         },
         "cachetools": {
             "hashes": [
@@ -287,15 +287,16 @@
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:8eb2cbc91b69feaf23e32452a7ae60e791e09967d81d4fcc7fc388182d1bd394",
-                "sha256:c25873c47279387cfdcbdafa36149887901d36202cb645a0e4f29686bf6e4417"
+                "sha256:27a849d6205838fb6cc3c1c21cb9800707a661bb21c6ce7fb13e99eb1f8a0c46",
+                "sha256:a9f4a1d7f6d9809657b7f1316a1aa527f6664891531bcfcc13b6696e685f443c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.56.4"
+            "version": "==1.57.0"
         },
         "greenlet": {
             "hashes": [
                 "sha256:0109af1138afbfb8ae647e31a2b1ab030f58b21dd8528c27beaeb0093b7938a9",
+                "sha256:0459d94f73265744fee4c2d5ec44c6f34aa8a31017e6e9de770f7bcf29710be9",
                 "sha256:04957dc96669be041e0c260964cfef4c77287f07c40452e61abe19d647505581",
                 "sha256:0722c9be0797f544a3ed212569ca3fe3d9d1a1b13942d10dd6f0e8601e484d26",
                 "sha256:097e3dae69321e9100202fc62977f687454cd0ea147d0fd5a766e57450c569fd",
@@ -320,6 +321,7 @@
                 "sha256:56961cfca7da2fdd178f95ca407fa330c64f33289e1804b592a77d5593d9bd94",
                 "sha256:5a8e05057fab2a365c81abc696cb753da7549d20266e8511eb6c9d9f72fe3e92",
                 "sha256:659f167f419a4609bc0516fb18ea69ed39dbb25594934bd2dd4d0401660e8a1e",
+                "sha256:662e8f7cad915ba75d8017b3e601afc01ef20deeeabf281bd00369de196d7726",
                 "sha256:6f61d71bbc9b4a3de768371b210d906726535d6ca43506737682caa754b956cd",
                 "sha256:72b00a8e7c25dcea5946692a2485b1a0c0661ed93ecfedfa9b6687bd89a24ef5",
                 "sha256:811e1d37d60b47cb8126e0a929b58c046251f28117cb16fcd371eed61f66b764",
@@ -345,6 +347,7 @@
                 "sha256:cce1e90dd302f45716a7715517c6aa0468af0bf38e814ad4eab58e88fc09f7f7",
                 "sha256:cd4ccc364cf75d1422e66e247e52a93da6a9b73cefa8cad696f3cbbb75af179d",
                 "sha256:d21681f09e297a5adaa73060737e3aa1279a13ecdcfcc6ef66c292cb25125b2d",
+                "sha256:d38ffd0e81ba8ef347d2be0772e899c289b59ff150ebbbbe05dc61b1246eb4e0",
                 "sha256:d566b82e92ff2e09dd6342df7e0eb4ff6275a3f08db284888dcd98134dbd4243",
                 "sha256:d5b0ff9878333823226d270417f24f4d06f235cb3e54d1103b71ea537a6a86ce",
                 "sha256:d6ee1aa7ab36475035eb48c01efae87d37936a8173fc4d7b10bb02c2d75dd8f6",
@@ -398,11 +401,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:5bfcf2bca16a087ade17e02b282d34af7ccd749ef76241e7f9bd7c0cb8a9424d",
-                "sha256:f660066c3966db7d6daeaea8a75e0b68237a48e51cf49882087757bb59916248"
+                "sha256:05b2d22c83640cde0b7e0aa329ca7754fbd98ea66ad8ae24aa61328dfe057fa3",
+                "sha256:410ef23dcdbca4eaedc08b850079179883c2ed09378bd1f760d4af4aacfa28d7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.17.0"
+            "version": "==4.17.1"
         },
         "markupsafe": {
             "hashes": [
@@ -624,7 +627,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "pytz": {
@@ -660,74 +663,74 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
-                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
+                "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840",
+                "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.5.1"
+            "version": "==65.6.0"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0c8a174f23bc021aac97bcb27fbe2ae3d4652d3d23e5768bc2ec3d44e386c7eb",
-                "sha256:13ce4f3a068ec4ef7598d2a77f42adc3d90c76981f5a7c198756b25c4f4a22ea",
-                "sha256:1d16aca30fad4753aeb4ebde564bbd4a248b9673e4f879b940f4e806a17be87f",
-                "sha256:23a4569d3db1ce44370d05c5ad79be4f37915fcc97387aef9da232b95db7b695",
-                "sha256:27479b5a1e110e64c56b18ffbf8cf99e101572a3d1a43943ea02158f1304108e",
-                "sha256:2fef01240d32ada9007387afd8e0b2230f99efdc4b57ca6f1d1192fca4fcf6a5",
-                "sha256:35dc0a5e934c41e282e019c889069b01ff4cd356b2ea452c9985e1542734cfb1",
-                "sha256:41df873cdae1d56fde97a1b4f6ffa118f40e4b2d6a6aa8c25c50eea31ecbeb08",
-                "sha256:42bff29eaecbb284f614f4bb265bb0c268625f5b93ce6268f8017811e0afbdde",
-                "sha256:491d94879f9ec0dea7e1cb053cd9cc65a28d2467960cf99f7b3c286590406060",
-                "sha256:4a791e7a1e5ac33f70a3598f8f34fdd3b60c68593bbb038baf58bc50e02d7468",
-                "sha256:4abda3e693d24169221ffc7aa0444ccef3dc43dfeab6ad8665d3836751cd6af7",
-                "sha256:529e2cc8af75811114e5ab2eb116fd71b6e252c6bdb32adbfcd5e0c5f6d5ab06",
-                "sha256:59bd0ae166253f7fed8c3f4f6265d2637f25d2f6614d00df34d7ee0d95d29c91",
-                "sha256:5d5937e1bf7921e4d1acdfad72dd98d9e7f9ea5c52aeb12b3b05b534b527692d",
-                "sha256:6b462c070769f0ef06ea5fe65206b970bcf2b59cb3fda2bec2f4729e1be89c13",
-                "sha256:736d4e706adb3c95a0a7e660073a5213dfae78ff2df6addf8ff2918c83fbeebe",
-                "sha256:7d6293010aa0af8bd3b0c9993259f8979db2422d6abf85a31d70ec69cb2ee4dc",
-                "sha256:962c7c80c54a42836c47cb0d8a53016986c8584e8d98e90e2ea723a4ed0ba85b",
-                "sha256:a22f46440e61d90100e0f378faac40335fb5bbf278472df0d83dc15b653b9896",
-                "sha256:a7fa3e57a7b0476fbcba72b231150503d53dbcbdd23f4a86be5152912a923b6e",
-                "sha256:aa12e27cb465b4b006ffb777624fc6023363e01cfed2d3f89d33fb6da80f6de2",
-                "sha256:b6fd58e25e6cdd2a131d7e97f9713f8f2142360cd40c75af8aa5b83d535f811c",
-                "sha256:bd80300d81d92661e2488a4bf4383f0c5dc6e7b05fa46d2823e231af4e30539a",
-                "sha256:c1ced2fae7a1177a36cf94d0a5567452d195d3b4d7d932dd61f123fb15ddf87b",
-                "sha256:c1f5bfffc3227d05d90c557b10604962f655b4a83c9f3ad507a81ac8d6847679",
-                "sha256:c3dde668edea70dc8d55a74d933d5446e5a97786cdd1c67c8e4971c73bd087ad",
-                "sha256:c628697aad7a141da8fc3fd81b4874a711cc84af172e1b1e7bbfadf760446496",
-                "sha256:c6de20de7c19b965c007c9da240268dde1451865099ca10f0f593c347041b845",
-                "sha256:c9a6e878e63286392b262d86d21fe16e6eec12b95ccb0a92c392f2b1e0acca03",
-                "sha256:c9b59863e2b1f1e1ebf9ee517f86cdfa82d7049c8d81ad71ab58d442b137bbe9",
-                "sha256:cde363fb5412ab178f1cc1e596e9cfc396464da8a4fe8e733cc6d6b4e2c23aa9",
-                "sha256:d05d7365c2d1df03a69d90157a3e9b3e7b62088cca8ee6686aed2598659a6e14",
-                "sha256:dc1e005d490c101d27657481a05765851ab795cc8aedeb8d9425595088b20736",
-                "sha256:ed1c950aba723b7a5b702b88f05d883607c587de918d7d8c2014fe7f55cf67e0",
-                "sha256:ee9613b0460dce970414cfc990ca40afe518bc139e697243fcdf890285fb30ac",
-                "sha256:eeb55a555eef1a9607c1635bbdddd0b8a2bb9713bcb5bc8da1e8fae8ee46d1d8",
-                "sha256:f5438f6c768b7e928f0463777b545965648ba0d55877afd14a4e96d2a99702e7",
-                "sha256:f6e036714a586f757a3e12ff0798ce9a90aa04a60cff392d8bcacc5ecf79c95e",
-                "sha256:fa46d86a17cccd48c6762df1a60aecf5aaa2e0c0973efacf146c637694b62ffd",
-                "sha256:fb9a44e7124f72b79023ab04e1c8fcd8f392939ef0d7a75beae8634e15605d30"
+                "sha256:0be9b479c5806cece01f1581726573a8d6515f8404e082c375b922c45cfc2a7b",
+                "sha256:17aee7bfcef7bf0dea92f10e5dfdd67418dcf6fe0759f520e168b605855c003e",
+                "sha256:21f3df74a0ab39e1255e94613556e33c1dc3b454059fe0b365ec3bbb9ed82e4a",
+                "sha256:237067ba0ef45a518b64606e1807f7229969ad568288b110ed5f0ca714a3ed3a",
+                "sha256:2dda5f96719ae89b3ec0f1b79698d86eb9aecb1d54e990abb3fdd92c04b46a90",
+                "sha256:393f51a09778e8984d735b59a810731394308b4038acdb1635397c2865dae2b6",
+                "sha256:3ca21b35b714ce36f4b8d1ee8d15f149db8eb43a472cf71600bf18dae32286e7",
+                "sha256:3cbdbed8cdcae0f83640a9c44fa02b45a6c61e149c58d45a63c9581aba62850f",
+                "sha256:3eba07f740488c3a125f17c092a81eeae24a6c7ec32ac9dbc52bf7afaf0c4f16",
+                "sha256:3f68eab46649504eb95be36ca529aea16cd199f080726c28cbdbcbf23d20b2a2",
+                "sha256:4c56e6899fa6e767e4be5d106941804a4201c5cb9620a409c0b80448ec70b656",
+                "sha256:53f90a2374f60e703c94118d21533765412da8225ba98659de7dd7998641ab17",
+                "sha256:595b185041a4dc5c685283ea98c2f67bbfa47bb28e4a4f5b27ebf40684e7a9f8",
+                "sha256:65a0ad931944fcb0be12a8e0ac322dbd3ecf17c53f088bc10b6da8f0caac287b",
+                "sha256:68e0cd5d32a32c4395168d42f2fefbb03b817ead3a8f3704b8bd5697c0b26c24",
+                "sha256:6a06c2506c41926d2769f7968759995f2505e31c5b5a0821e43ca5a3ddb0e8ae",
+                "sha256:6d7e1b28342b45f19e3dea7873a9479e4a57e15095a575afca902e517fb89652",
+                "sha256:6f0ea4d7348feb5e5d0bf317aace92e28398fa9a6e38b7be9ec1f31aad4a8039",
+                "sha256:7313e4acebb9ae88dbde14a8a177467a7625b7449306c03a3f9f309b30e163d0",
+                "sha256:7cf7c7adbf4417e3f46fc5a2dbf8395a5a69698217337086888f79700a12e93a",
+                "sha256:80ead36fb1d676cc019586ffdc21c7e906ce4bf243fe4021e4973dae332b6038",
+                "sha256:9470633395e5f24d6741b4c8a6e905bce405a28cf417bba4ccbaadf3dab0111d",
+                "sha256:94c0093678001f5d79f2dcbf3104c54d6c89e41ab50d619494c503a4d3f1aef2",
+                "sha256:95f4f8d62589755b507218f2e3189475a4c1f5cc9db2aec772071a7dc6cd5726",
+                "sha256:9c857676d810ca196be73c98eb839125d6fa849bfa3589be06201a6517f9961c",
+                "sha256:a22208c1982f1fe2ae82e5e4c3d4a6f2445a7a0d65fb7983a3d7cbbe3983f5a4",
+                "sha256:ad5f966623905ee33694680dda1b735544c99c7638f216045d21546d3d8c6f5b",
+                "sha256:ae1ed1ebc407d2f66c6f0ec44ef7d56e3f455859df5494680e2cf89dad8e3ae0",
+                "sha256:afd1ac99179d1864a68c06b31263a08ea25a49df94e272712eb2824ef151e294",
+                "sha256:b6a337a2643a41476fb6262059b8740f4b9a2ec29bf00ffb18c18c080f6e0aed",
+                "sha256:b737fbeb2f78926d1f59964feb287bbbd050e7904766f87c8ce5cfb86e6d840c",
+                "sha256:c46322354c58d4dc039a2c982d28284330f8919f31206894281f4b595b9d8dbe",
+                "sha256:c7e3b9e01fdbe1ce3a165cc7e1ff52b24813ee79c6df6dee0d1e13888a97817e",
+                "sha256:c9aa372b295a36771cffc226b6517df3011a7d146ac22d19fa6a75f1cdf9d7e6",
+                "sha256:d3b6d4588994da73567bb00af9d7224a16c8027865a8aab53ae9be83f9b7cbd1",
+                "sha256:d3b9ac11f36ab9a726097fba7c7f6384f0129aedb017f1d4d1d4fce9052a1320",
+                "sha256:d654870a66027af3a26df1372cf7f002e161c6768ebe4c9c6fdc0da331cb5173",
+                "sha256:d8080bc51a775627865e0f1dbfc0040ff4ace685f187f6036837e1727ba2ed10",
+                "sha256:da60b98b0f6f0df9fbf8b72d67d13b73aa8091923a48af79a951d4088530a239",
+                "sha256:f5e8ed9cde48b76318ab989deeddc48f833d2a6a7b7c393c49b704f67dedf01d",
+                "sha256:f8e5443295b218b08bef8eb85d31b214d184b3690d99a33b7bd8e5591e2b0aa1"
             ],
             "index": "pypi",
-            "version": "==1.4.43"
+            "version": "==1.4.44"
         },
         "structlog": {
             "hashes": [
-                "sha256:760d37b8839bd4fe1747bed7b80f7f4de160078405f4b6a1db9270ccbfce6c30",
-                "sha256:94b29b1d62b2659db154f67a9379ec1770183933d6115d21f21aa25cfc9a7393"
+                "sha256:4edfe1d9f15f8a4bf365a817f7182af5d610596c155434b7564bfe7d40c2753c",
+                "sha256:bb1aa189214c30372a8afaa592f9556756aeb690e1ad7eb34391d7b5fa0f09b2"
             ],
             "index": "pypi",
-            "version": "==22.1.0"
+            "version": "==22.2.0"
         },
         "urllib3": {
             "hashes": [
@@ -754,49 +757,45 @@
         },
         "zope.interface": {
             "hashes": [
-                "sha256:026e7da51147910435950a46c55159d68af319f6e909f14873d35d411f4961db",
-                "sha256:061a41a3f96f076686d7f1cb87f3deec6f0c9f0325dcc054ac7b504ae9bb0d82",
-                "sha256:0eda7f61da6606a28b5efa5d8ad79b4b5bb242488e53a58993b2ec46c924ffee",
-                "sha256:13a7c6e3df8aa453583412de5725bf761217d06f66ff4ed776d44fbcd13ec4e4",
-                "sha256:185f0faf6c3d8f2203e8755f7ca16b8964d97da0abde89c367177a04e36f2568",
-                "sha256:2204a9d545fdbe0d9b0bf4d5e2fc67e7977de59666f7131c1433fde292fc3b41",
-                "sha256:27c53aa2f46d42940ccdcb015fd525a42bf73f94acd886296794a41f229d5946",
-                "sha256:3c293c5c0e1cabe59c33e0d02fcee5c3eb365f79a20b8199a26ca784e406bd0d",
-                "sha256:3e42b1c3f4fd863323a8275c52c78681281a8f2e1790f0e869d911c1c7b25c46",
-                "sha256:3e5540b7d703774fd171b7a7dc2a3cb70e98fc273b8b260b1bf2f7d3928f125b",
-                "sha256:4477930451521ac7da97cc31d49f7b83086d5ae76e52baf16aac659053119f6d",
-                "sha256:475b6e371cdbeb024f2302e826222bdc202186531f6dc095e8986c034e4b7961",
-                "sha256:489c4c46fcbd9364f60ff0dcb93ec9026eca64b2f43dc3b05d0724092f205e27",
-                "sha256:509a8d39b64a5e8d473f3f3db981f3ca603d27d2bc023c482605c1b52ec15662",
-                "sha256:58331d2766e8e409360154d3178449d116220348d46386430097e63d02a1b6d2",
-                "sha256:59a96d499ff6faa9b85b1309f50bf3744eb786e24833f7b500cbb7052dc4ae29",
-                "sha256:6cb8f9a1db47017929634264b3fc7ea4c1a42a3e28d67a14f14aa7b71deaa0d2",
-                "sha256:6cf30ac555aacabee24ae316cbe5f0a1e7b40a9fd3dff2d4afe4229de1fc9069",
-                "sha256:6d678475fdeb11394dc9aaa5c564213a1567cc663082e0ee85d52f78d1fbaab2",
-                "sha256:72a93445937cc71f0b8372b0c9e7c185328e0db5e94d06383a1cb56705df1df4",
-                "sha256:76cf472c79d15dce5f438a4905a1309be57d2d01bc1de2de30bda61972a79ab4",
-                "sha256:7b4547a2f624a537e90fb99cec4d8b3b6be4af3f449c3477155aae65396724ad",
-                "sha256:7f2e4ebe0a000c5727ee04227cf0ff5ae612fe599f88d494216e695b1dac744d",
-                "sha256:8343536ea4ee15d6525e3e726bb49ffc3f2034f828a49237a36be96842c06e7c",
-                "sha256:8de7bde839d72d96e0c92e8d1fdb4862e89b8fc52514d14b101ca317d9bcf87c",
-                "sha256:90f611d4cdf82fb28837fe15c3940255755572a4edf4c72e2306dbce7dcb3092",
-                "sha256:9ad58724fabb429d1ebb6f334361f0a3b35f96be0e74bfca6f7de8530688b2df",
-                "sha256:a1393229c9c126dd1b4356338421e8882347347ab6fe3230cb7044edc813e424",
-                "sha256:a20fc9cccbda2a28e8db8cabf2f47fead7e9e49d317547af6bf86a7269e4b9a1",
-                "sha256:a69f6d8b639f2317ba54278b64fef51d8250ad2c87acac1408b9cc461e4d6bb6",
-                "sha256:a6f51ffbdcf865f140f55c484001415505f5e68eb0a9eab1d37d0743b503b423",
-                "sha256:c9552ee9e123b7997c7630fb95c466ee816d19e721c67e4da35351c5f4032726",
-                "sha256:cd423d49abcf0ebf02c29c3daffe246ff756addb891f8aab717b3a4e2e1fd675",
-                "sha256:d0587d238b7867544134f4dcca19328371b8fd03fc2c56d15786f410792d0a68",
-                "sha256:d1f2d91c9c6cd54d750fa34f18bd73c71b372d0e6d06843bc7a5f21f5fd66fe0",
-                "sha256:d743b03a72fefed807a4512c079fb1aa5e7777036cc7a4b6ff79ae4650a14f73",
-                "sha256:dd4b9251e95020c3d5d104b528dbf53629d09c146ce9c8dfaaf8f619ae1cce35",
-                "sha256:e4988d94962f517f6da2d52337170b84856905b31b7dc504ed9c7b7e4bab2fc3",
-                "sha256:e6a923d2dec50f2b4d41ce198af3516517f2e458220942cf393839d2f9e22000",
-                "sha256:e8c8764226daad39004b7873c3880eb4860c594ff549ea47c045cdf313e1bad5"
+                "sha256:008b0b65c05993bb08912f644d140530e775cf1c62a072bf9340c2249e613c32",
+                "sha256:0217a9615531c83aeedb12e126611b1b1a3175013bbafe57c702ce40000eb9a0",
+                "sha256:0fb497c6b088818e3395e302e426850f8236d8d9f4ef5b2836feae812a8f699c",
+                "sha256:17ebf6e0b1d07ed009738016abf0d0a0f80388e009d0ac6e0ead26fc162b3b9c",
+                "sha256:311196634bb9333aa06f00fc94f59d3a9fddd2305c2c425d86e406ddc6f2260d",
+                "sha256:3218ab1a7748327e08ef83cca63eea7cf20ea7e2ebcb2522072896e5e2fceedf",
+                "sha256:404d1e284eda9e233c90128697c71acffd55e183d70628aa0bbb0e7a3084ed8b",
+                "sha256:4087e253bd3bbbc3e615ecd0b6dd03c4e6a1e46d152d3be6d2ad08fbad742dcc",
+                "sha256:40f4065745e2c2fa0dff0e7ccd7c166a8ac9748974f960cd39f63d2c19f9231f",
+                "sha256:5334e2ef60d3d9439c08baedaf8b84dc9bb9522d0dacbc10572ef5609ef8db6d",
+                "sha256:604cdba8f1983d0ab78edc29aa71c8df0ada06fb147cea436dc37093a0100a4e",
+                "sha256:6373d7eb813a143cb7795d3e42bd8ed857c82a90571567e681e1b3841a390d16",
+                "sha256:655796a906fa3ca67273011c9805c1e1baa047781fca80feeb710328cdbed87f",
+                "sha256:65c3c06afee96c654e590e046c4a24559e65b0a87dbff256cd4bd6f77e1a33f9",
+                "sha256:696f3d5493eae7359887da55c2afa05acc3db5fc625c49529e84bd9992313296",
+                "sha256:6e972493cdfe4ad0411fd9abfab7d4d800a7317a93928217f1a5de2bb0f0d87a",
+                "sha256:7579960be23d1fddecb53898035a0d112ac858c3554018ce615cefc03024e46d",
+                "sha256:765d703096ca47aa5d93044bf701b00bbce4d903a95b41fff7c3796e747b1f1d",
+                "sha256:7e66f60b0067a10dd289b29dceabd3d0e6d68be1504fc9d0bc209cf07f56d189",
+                "sha256:8a2ffadefd0e7206adc86e492ccc60395f7edb5680adedf17a7ee4205c530df4",
+                "sha256:959697ef2757406bff71467a09d940ca364e724c534efbf3786e86eee8591452",
+                "sha256:9d783213fab61832dbb10d385a319cb0e45451088abd45f95b5bb88ed0acca1a",
+                "sha256:a16025df73d24795a0bde05504911d306307c24a64187752685ff6ea23897cb0",
+                "sha256:a2ad597c8c9e038a5912ac3cf166f82926feff2f6e0dabdab956768de0a258f5",
+                "sha256:bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671",
+                "sha256:d169ccd0756c15bbb2f1acc012f5aab279dffc334d733ca0d9362c5beaebe88e",
+                "sha256:d514c269d1f9f5cd05ddfed15298d6c418129f3f064765295659798349c43e6f",
+                "sha256:d692374b578360d36568dd05efb8a5a67ab6d1878c29c582e37ddba80e66c396",
+                "sha256:dbaeb9cf0ea0b3bc4b36fae54a016933d64c6d52a94810a63c00f440ecb37dd7",
+                "sha256:dc26c8d44472e035d59d6f1177eb712888447f5799743da9c398b0339ed90b1b",
+                "sha256:e1574980b48c8c74f83578d1e77e701f8439a5d93f36a5a0af31337467c08fcf",
+                "sha256:e74a578172525c20d7223eac5f8ad187f10940dac06e40113d62f14f3adb1e8f",
+                "sha256:e945de62917acbf853ab968d8916290548df18dd62c739d862f359ecd25842a6",
+                "sha256:f0980d44b8aded808bec5059018d64692f0127f10510eca71f2f0ace8fb11188",
+                "sha256:f98d4bd7bbb15ca701d19b93263cc5edfd480c3475d163f137385f49e5b3a3a7",
+                "sha256:fb68d212efd057596dee9e6582daded9f8ef776538afdf5feceb3059df2d2e7b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.5.1"
+            "version": "==5.5.2"
         }
     },
     "develop": {
@@ -947,19 +946,19 @@
         },
         "pathspec": {
             "hashes": [
-                "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93",
-                "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
+                "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5",
+                "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.10.1"
+            "version": "==0.10.2"
         },
         "platformdirs": {
             "hashes": [
-                "sha256:0cb405749187a194f444c25c82ef7225232f11564721eabffc6ec70df83b11cb",
-                "sha256:6e52c21afff35cb659c6e52d8b4d61b9bd544557180440538f255d9382c8cbe0"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.3"
+            "version": "==2.5.4"
         },
         "pluggy": {
             "hashes": [

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.53
+version: 2.0.54
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.53
+appVersion: 2.0.54

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.51
+version: 2.0.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.51
+appVersion: 2.0.52

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.54
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.0.54
+appVersion: 3.0.0

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -156,6 +156,12 @@ spec:
               secretKeyRef:
                 name: db-credentials
                 key: {{ .Values.database.secrets.casePasswordKey }}
+          - name: CASE_DATABASE_URI
+            {{- if .Values.database.sqlProxyEnabled }}
+            value: "postgresql://$(CASE_DB_USERNAME):$(CASE_DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(CASE_DB_NAME)"
+            {{- else }}
+            value: "postgresql://$(CASE_DB_USERNAME):$(CASE_DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(CASE_DB_NAME)"
+            {{- end }}
           - name: PARTY_DB_NAME
             valueFrom:
               secretKeyRef:
@@ -171,6 +177,14 @@ spec:
               secretKeyRef:
                 name: db-credentials
                 key: {{ .Values.database.secrets.partyPasswordKey }}
+          - name: PARTY_DATABASE_URI
+            {{- if .Values.database.sqlProxyEnabled }}
+            value: "postgresql://$(PARTY_DB_USERNAME):$(PARTY_DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(PARTY_DB_NAME)"
+            {{- else }}
+            value: "postgresql://$(PARTY_DB_USERNAME):$(PARTY_DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(PARTY_DB_NAME)"
+            {{- end }}
+
+
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/secrets/google/credentials.json
           resources:

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.32.0
           command: ["/cloud_sql_proxy",
-                    "-instances=$(SQL_INSTANCE_NAME)=tcp:$(DB_PORT)",
+                    "-instances=$(READ_REPLICA_INSTANCE_NAME)=tcp:$(DB_PORT)",
                     "-ip_address_types=PRIVATE",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           securityContext:
@@ -50,11 +50,11 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
           env:
-          - name: SQL_INSTANCE_NAME
+          - name: READ_REPLICA_INSTANCE_NAME
             valueFrom:
               configMapKeyRef:
                 name: cloudsql-proxy-config
-                key: reporting-connection-name
+                key: replica-connection-name
           - name: DB_PORT
             valueFrom:
               secretKeyRef:
@@ -141,6 +141,36 @@ spec:
             {{- else }}
             value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
             {{- end }}
+          - name: CASE_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: {{ .Values.database.secrets.caseNameKey }}
+          - name: CASE_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: {{ .Values.database.secrets.caseUserNameKey }}
+          - name: CASE_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: {{ .Values.database.secrets.casePasswordKey }}
+          - name: PARTY_DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: db-config
+                key: {{ .Values.database.secrets.partyNameKey }}
+          - name: PARTY_DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: {{ .Values.database.secrets.partyUserNameKey }}
+          - name: PARTY_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: db-credentials
+                key: {{ .Values.database.secrets.partyPasswordKey }}
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/secrets/google/credentials.json
           resources:

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -135,12 +135,6 @@ spec:
                 key: security-password
           - name: PORT
             value: "{{ .Values.container.port }}"
-          - name: DATABASE_URI
-            {{- if .Values.database.sqlProxyEnabled }}
-            value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@127.0.0.1:$(DB_PORT)/$(DB_NAME)"
-            {{- else }}
-            value: "postgresql://$(DB_USERNAME):$(DB_PASSWORD)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)"
-            {{- end }}
           - name: CASE_DB_NAME
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/reporting/templates/deployment.yaml
+++ b/_infra/helm/reporting/templates/deployment.yaml
@@ -108,21 +108,6 @@ spec:
               secretKeyRef:
                 name: db-config
                 key: db-port
-          - name: DB_NAME
-            valueFrom:
-              secretKeyRef:
-                name: db-config
-                key: {{ .Values.database.secrets.nameKey }}
-          - name: DB_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: db-credentials
-                key: {{ .Values.database.secrets.usernameKey }}
-          - name: DB_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: db-credentials
-                key: {{ .Values.database.secrets.passwordKey }}
           - name: SECURITY_USER_NAME
             valueFrom:
               secretKeyRef:

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -14,15 +14,15 @@ service:
 resources:
   application:
     requests:
-      memory: "125Mi"
       cpu: "50m"
+      memory: "125Mi"
     limits:
       cpu: "200m"
       memory: "350Mi"
   proxy:
     requests:
+      cpu: "10m"
       memory: "25Mi"
-      cpu: "5m"
     limits:
       cpu: "100m"
       memory: "256Mi"
@@ -42,9 +42,6 @@ database:
   sqlProxyEnabled: false
   managedPostgres: false
   secrets:
-    usernameKey: username
-    passwordKey: password
-    nameKey: db-name
     caseUserNameKey: username
     casePasswordKey: password
     caseNameKey: db-name

--- a/_infra/helm/reporting/values.yaml
+++ b/_infra/helm/reporting/values.yaml
@@ -45,3 +45,9 @@ database:
     usernameKey: username
     passwordKey: password
     nameKey: db-name
+    caseUserNameKey: username
+    casePasswordKey: password
+    caseNameKey: db-name
+    partyUserNameKey: username
+    partyPasswordKey: password
+    partyNameKey: db-name

--- a/config.py
+++ b/config.py
@@ -10,11 +10,8 @@ class Config(object):
     SECURITY_USER_NAME = os.getenv("SECURITY_USER_NAME")
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
-    DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/ras")
-    DATABASE_BINDS = {
-        "case_db": os.getenv("CASE_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras"),
-        "party_db": os.getenv("PARTY_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras"),
-    }
+    CASE_DATABASE_URI = os.getenv("CASE_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras")
+    PARTY_DATABASE_URI = os.getenv("PARTY_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras")
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
 

--- a/config.py
+++ b/config.py
@@ -11,6 +11,10 @@ class Config(object):
     SECURITY_USER_PASSWORD = os.getenv("SECURITY_USER_PASSWORD")
     BASIC_AUTH = (SECURITY_USER_NAME, SECURITY_USER_PASSWORD)
     DATABASE_URI = os.getenv("DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/ras")
+    DATABASE_BINDS = {
+        "case_db": os.getenv("CASE_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras"),
+        "party_db": os.getenv("PARTY_DATABASE_URI", "postgresql://postgres:postgres@127.0.0.1:5432/ras"),
+    }
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
 
 

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -11,9 +11,8 @@ from rm_reporting.logger_config import logger_initial_config
 
 
 def initialise_db(app):
-    app.db = create_connection(app.config["DATABASE_URI"])
-    app.case_db = create_connection(app.config["DATABASE_BINDS"]["case_db"])
-    app.party_db = create_connection(app.config["DATABASE_BINDS"]["party_db"])
+    app.case_db = create_connection(app.config["CASE_DATABASE_URI"])
+    app.party_db = create_connection(app.config["PARTY_DATABASE_URI"])
 
 
 def create_connection(db_connection_uri):
@@ -31,8 +30,6 @@ app = Flask(__name__)
 
 app_config = f"config.{os.environ.get('APP_SETTINGS', 'Config')}"
 app.config.from_object(app_config)
-# supports multiple db connections
-app.config["SQLALCHEMY_BINDS"] = app.config["DATABASE_BINDS"]
 
 app.url_map.strict_slashes = False
 

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -29,6 +29,8 @@ app = Flask(__name__)
 
 app_config = f"config.{os.environ.get('APP_SETTINGS', 'Config')}"
 app.config.from_object(app_config)
+# supports multiple db connections
+app.config["SQLALCHEMY_BINDS"] = app.config["DATABASE_BINDS"]
 
 app.url_map.strict_slashes = False
 

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -53,7 +53,6 @@ api.add_namespace(response_dashboard_api)
 
 from rm_reporting.resources.info import Info  # NOQA
 from rm_reporting.resources.response_chasing import ResponseChasingDownload  # NOQA
-from rm_reporting.resources.response_chasing import SocialMIDownload  # NOQA
 from rm_reporting.resources.responses_dashboard import ResponseDashboard  # NOQA
 
 api.init_app(app)

--- a/rm_reporting/__init__.py
+++ b/rm_reporting/__init__.py
@@ -12,6 +12,8 @@ from rm_reporting.logger_config import logger_initial_config
 
 def initialise_db(app):
     app.db = create_connection(app.config["DATABASE_URI"])
+    app.case_db = create_connection(app.config["DATABASE_BINDS"]["case_db"])
+    app.party_db = create_connection(app.config["DATABASE_BINDS"]["party_db"])
 
 
 def create_connection(db_connection_uri):

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -8,7 +8,13 @@ from rm_reporting import app
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def get_case_data(collection_exercise_id) -> list:
+def get_case_data(collection_exercise_id: str) -> list:
+    """
+    Gets the party_id (for the business), ru_ref and submission status for every case for a
+    given collection_exercise_id
+    :param collection_exercise_id: A uuid for a collection exercise
+    :return:
+    """
     logger.info("About to get case data")
     case_engine = app.case_db.engine
     case_business_ids_query = text(
@@ -22,7 +28,23 @@ def get_case_data(collection_exercise_id) -> list:
     return case_result
 
 
-def get_exercise_completion_stats(collection_exercise_id) -> list:
+def get_business_ids_from_case_data(case_result) -> str:
+    """
+    Takes a list of case results and returns a comma separated list of business_ids.
+
+    :param case_result: A list of rows from a sqlAlchemy .all() result.
+    :return: A string with all the party_ids comma separated
+    """
+    # TODO get the values in a list in a tidier way...
+    business_ids_string = ""
+    for row in case_result:
+        business_ids_string += f"'{str(getattr(row, 'party_id'))}', "
+    # slice off the tailing ', '
+    business_ids_string = business_ids_string[:-2]
+    return business_ids_string
+
+
+def get_exercise_completion_stats(collection_exercise_id: str) -> list:
     case_engine = app.case_db.engine
     case_query = text(
         'SELECT COUNT(*) AS "Sample Size", '
@@ -38,7 +60,7 @@ def get_exercise_completion_stats(collection_exercise_id) -> list:
     return case_result
 
 
-def get_all_business_ids_for_collection_exercise(collection_exercise_id) -> str:
+def get_all_business_ids_for_collection_exercise(collection_exercise_id: str) -> str:
     case_engine = app.case_db.engine
     case_business_ids_query = text(
         "SELECT party_id "

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -8,7 +8,8 @@ from rm_reporting import app
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def get_case_data(collection_exercise_id):
+def get_case_data(collection_exercise_id) -> list:
+    logger.info("About to get case data")
     case_engine = app.case_db.engine
     case_business_ids_query = text(
         "SELECT party_id, sample_unit_ref, status "
@@ -16,6 +17,47 @@ def get_case_data(collection_exercise_id):
         "WHERE collection_exercise_id = :collection_exercise_id and "
         "sample_unit_ref NOT LIKE '1111%'"
     )
-    logger.info("About to get case data")
+
     case_result = case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
     return case_result
+
+
+def get_exercise_completion_stats(collection_exercise_id) -> list:
+    case_engine = app.case_db.engine
+    case_query = text(
+        'SELECT COUNT(*) AS "Sample Size", '
+        "COUNT(CASE WHEN status = 'NOTSTARTED' THEN 1 ELSE NULL END) AS \"Not Started\", "
+        "COUNT(CASE WHEN status = 'INPROGRESS' THEN 1 ELSE NULL END) AS \"In Progress\", "
+        "COUNT(CASE WHEN status = 'COMPLETE' THEN 1 ELSE NULL END) AS \"Complete\" "
+        "FROM casesvc.casegroup "
+        "WHERE collection_exercise_id = :collection_exercise_id "
+        "AND sample_unit_ref NOT LIKE '1111%'"
+    )
+
+    case_result = case_engine.execute(case_query, collection_exercise_id=collection_exercise_id).all()
+    return case_result
+
+
+def get_all_business_ids_for_collection_exercise(collection_exercise_id) -> str:
+    case_engine = app.case_db.engine
+    case_business_ids_query = text(
+        "SELECT party_id "
+        "FROM casesvc.casegroup "
+        "WHERE collection_exercise_id = :collection_exercise_id and "
+        "sample_unit_ref NOT LIKE '1111%'"
+    )
+
+    case_business_ids_result = case_engine.execute(
+        case_business_ids_query, collection_exercise_id=collection_exercise_id
+    )
+
+    business_id_result = case_business_ids_result.all()
+    # Ideally we'd use ','.join(business_id_result) but as it's not free to create a list of the ids, this is the
+    # next best thing.
+    business_ids_string = ""
+    for row in business_id_result:
+        business_ids_string += f"'{str(getattr(row, 'party_id'))}', "
+
+    # slice off the tailing ', '
+    business_ids_string = business_ids_string[:-2]
+    return business_ids_string

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -1,0 +1,21 @@
+import logging
+
+from sqlalchemy import text
+from structlog import wrap_logger
+
+from rm_reporting import app
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_case_data(collection_exercise_id):
+    case_engine = app.case_db.engine
+    case_business_ids_query = text(
+        "SELECT party_id, sample_unit_ref, status "
+        "FROM casesvc.casegroup "
+        "WHERE collection_exercise_id = :collection_exercise_id and "
+        "sample_unit_ref NOT LIKE '1111%'"
+    )
+    logger.info("About to get case data")
+    case_result = case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
+    return case_result

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -66,7 +66,7 @@ def get_exercise_completion_stats(collection_exercise_id: str) -> list:
 
 
 def get_all_business_ids_for_collection_exercise(collection_exercise_id: str) -> str:
-    logger.info("About to get all business  ids for collection exercise", collection_exercise_id=collection_exercise_id)
+    logger.info("About to get all business ids for collection exercise", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
         "SELECT party_id "

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -12,10 +12,11 @@ def get_case_data(collection_exercise_id: str) -> list:
     """
     Gets the party_id (for the business), ru_ref and submission status for every case for a
     given collection_exercise_id
+
     :param collection_exercise_id: A uuid for a collection exercise
-    :return:
+    :return: A list with all the rows found in the query
     """
-    logger.info("About to get case data")
+    logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
         "SELECT party_id, sample_unit_ref, status "
@@ -24,8 +25,7 @@ def get_case_data(collection_exercise_id: str) -> list:
         "ORDER BY sample_unit_ref, status"
     )
 
-    case_result = case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
-    return case_result
+    return case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
 
 
 def get_business_ids_from_case_data(case_result: list) -> str:
@@ -39,11 +39,18 @@ def get_business_ids_from_case_data(case_result: list) -> str:
     for row in case_result:
         business_ids_string += f"'{str(getattr(row, 'party_id'))}', "
     # slice off the tailing ', '
-    business_ids_string = business_ids_string[:-2]
-    return business_ids_string
+    return business_ids_string[:-2]
 
 
 def get_exercise_completion_stats(collection_exercise_id: str) -> list:
+    """
+    Gets the case completion stats for a given collection exercise.  The fields in the single returned row in the list
+    are: "Sample Size", "Not Started", "In Progress" and "Complete"
+
+    :param collection_exercise_id: A uuid for a collection exercise
+    :return: A list with a single row of data with the various counts
+    """
+    logger.info("About to get exercise completion stats", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_query = text(
         'SELECT COUNT(*) AS "Sample Size", '
@@ -55,11 +62,11 @@ def get_exercise_completion_stats(collection_exercise_id: str) -> list:
         "AND sample_unit_ref NOT LIKE '1111%'"
     )
 
-    case_result = case_engine.execute(case_query, collection_exercise_id=collection_exercise_id).all()
-    return case_result
+    return case_engine.execute(case_query, collection_exercise_id=collection_exercise_id).all()
 
 
 def get_all_business_ids_for_collection_exercise(collection_exercise_id: str) -> str:
+    logger.info("About to get all business  ids for collection exercise", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
         "SELECT party_id "
@@ -68,11 +75,10 @@ def get_all_business_ids_for_collection_exercise(collection_exercise_id: str) ->
         "sample_unit_ref NOT LIKE '1111%'"
     )
 
-    case_business_ids_result = case_engine.execute(
+    business_id_result = case_engine.execute(
         case_business_ids_query, collection_exercise_id=collection_exercise_id
-    )
+    ).all()
 
-    business_id_result = case_business_ids_result.all()
     # Ideally we'd use ','.join(business_id_result) but as it's not free to create a list of the ids, this is the
     # next best thing.
     business_ids_string = ""
@@ -80,5 +86,4 @@ def get_all_business_ids_for_collection_exercise(collection_exercise_id: str) ->
         business_ids_string += f"'{str(getattr(row, 'party_id'))}', "
 
     # slice off the tailing ', '
-    business_ids_string = business_ids_string[:-2]
-    return business_ids_string
+    return business_ids_string[:-2]

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -20,22 +20,21 @@ def get_case_data(collection_exercise_id: str) -> list:
     case_business_ids_query = text(
         "SELECT party_id, sample_unit_ref, status "
         "FROM casesvc.casegroup "
-        "WHERE collection_exercise_id = :collection_exercise_id and "
-        "sample_unit_ref NOT LIKE '1111%'"
+        "WHERE collection_exercise_id = :collection_exercise_id "
+        "ORDER BY sample_unit_ref, status"
     )
 
     case_result = case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
     return case_result
 
 
-def get_business_ids_from_case_data(case_result) -> str:
+def get_business_ids_from_case_data(case_result: list) -> str:
     """
     Takes a list of case results and returns a comma separated list of business_ids.
 
     :param case_result: A list of rows from a sqlAlchemy .all() result.
     :return: A string with all the party_ids comma separated
     """
-    # TODO get the values in a list in a tidier way...
     business_ids_string = ""
     for row in case_result:
         business_ids_string += f"'{str(getattr(row, 'party_id'))}', "

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -28,6 +28,10 @@ def get_attribute_data(collection_exercise_id):
 
 
 def get_enrolment_data(survey_id, business_ids_string) -> tuple[dict[str, list], str]:
+    # It shouldn't be possible for this to be empty as the download link only appears on live exercises.  But we
+    # don't want it to go bang if we say, hit the api directly for a not ready exercise
+    if business_ids_string == "":
+        return {}
     party_engine = app.party_db.engine
     # Get list of respondents for all those businesses for this survey (via enrolment table)
     # Get all the enrolments for the survey the exercise is for but only for the businesses
@@ -66,6 +70,11 @@ def get_enrolment_data(survey_id, business_ids_string) -> tuple[dict[str, list],
 
 def get_respondent_data(respondent_ids_string) -> dict:
     logger.info("About to get respondent data")
+    # It's possible for a new survey that there are no respondents yet, so we don't want it to break in that case
+    if respondent_ids_string == "":
+        logger.info("Returning empty respondent data dict")
+        return {}
+
     party_engine = app.party_db.engine
     respondent_details_query = text(f"SELECT * FROM partysvc.respondent r WHERE r.id IN ({respondent_ids_string}) ")
     respondent_details_result = party_engine.execute(respondent_details_query).all()

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -1,0 +1,75 @@
+import logging
+
+from sqlalchemy import text
+from structlog import wrap_logger
+
+from rm_reporting import app
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def get_attribute_data(collection_exercise_id):
+    party_engine = app.party_db.engine
+    # Get party attribute data for all those ru_refs (business_attributes table)
+    attributes = (
+        f"SELECT DISTINCT "
+        f"ba.collection_exercise As collection_exercise_uuid, "
+        f"ba.business_id AS business_party_uuid, "
+        f"ba.attributes->> 'name' AS business_name "
+        f"FROM partysvc.business_attributes ba "
+        f"WHERE "
+        f"ba.collection_exercise = '{collection_exercise_id}'"
+    )
+    logger.info("About to get party attributes")
+    attributes_result = party_engine.execute(attributes, collection_exercise_id=collection_exercise_id).all()
+    logger.info("Got party attributes")
+    return attributes_result
+
+
+def get_enrolment_data(survey_id, business_ids_string) -> dict:
+    party_engine = app.party_db.engine
+    # Get list of respondents for all those businesses for this survey (via enrolment table)
+    # Get all the enrolments for the survey the exercise is for but only for the businesses
+    enrolment_details_query_text = (
+        f"SELECT * "
+        f"FROM partysvc.enrolment e "
+        f"WHERE "
+        f"e.survey_id = :survey_id AND e.business_id IN ({business_ids_string}) "
+    )
+
+    enrolment_details_query = text(enrolment_details_query_text)
+    # TODO maybe loop over it, converting it into a dict keyed by the ru_ref for easy access later on as theres a
+    # lot of wasted work looping over all the results again and again
+    logger.info("About to get enrolment details")
+    enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id).all()
+
+    respondent_ids_string = ""
+    for row in enrolment_details_result:
+        respondent_ids_string += f"'{str(getattr(row, 'respondent_id'))}', "
+
+        # slice off the tailing ', '
+    respondent_ids_string = respondent_ids_string[:-2]
+
+    logger.info("Got enrolment details")
+    resulting_dict = {}
+    for row in enrolment_details_result:
+        business_id = str(getattr(row, 'business_id'))
+        if resulting_dict.get(business_id) is None:
+            resulting_dict[business_id] = [row]
+        else:
+            resulting_dict[business_id].append(row)
+
+    # example = {
+    #     '123': [{'respondent_id': 1, 'status': 'active'}, {'respondent_id': 2, 'status': 'active'}]
+    #     '456': [{'respondent_id': 1, 'status': 'active'}, {'respondent_id': 3, 'status': 'active'}]
+    # }
+    return resulting_dict, respondent_ids_string
+
+
+def get_respondent_data(respondent_ids_string) -> dict:
+    party_engine = app.party_db.engine
+    respondent_details_query_text = f"SELECT * FROM partysvc.respondent r WHERE r.id IN ({respondent_ids_string}) "
+    respondent_details_query = text(respondent_details_query_text)
+    respondent_details_result = party_engine.execute(respondent_details_query).all()
+    results_dict = {str(getattr(item, "id")): item for item in respondent_details_result}
+    return results_dict

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -22,12 +22,12 @@ def get_attribute_data(collection_exercise_id):
     )
     logger.info("About to get party attributes")
     attributes_result = party_engine.execute(attributes, collection_exercise_id=collection_exercise_id).all()
-    logger.info("Got party attributes")
     result_dict = {str(getattr(item, "business_party_uuid")): item for item in attributes_result}
+    logger.info("Got party attributes")
     return result_dict
 
 
-def get_enrolment_data(survey_id, business_ids_string) -> dict:
+def get_enrolment_data(survey_id, business_ids_string):
     party_engine = app.party_db.engine
     # Get list of respondents for all those businesses for this survey (via enrolment table)
     # Get all the enrolments for the survey the exercise is for but only for the businesses
@@ -39,8 +39,6 @@ def get_enrolment_data(survey_id, business_ids_string) -> dict:
     )
 
     enrolment_details_query = text(enrolment_details_query_text)
-    # TODO maybe loop over it, converting it into a dict keyed by the ru_ref for easy access later on as theres a
-    # lot of wasted work looping over all the results again and again
     logger.info("About to get enrolment details")
     enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id).all()
 
@@ -50,8 +48,6 @@ def get_enrolment_data(survey_id, business_ids_string) -> dict:
 
         # slice off the tailing ', '
     respondent_ids_string = respondent_ids_string[:-2]
-
-    logger.info("Got enrolment details")
     resulting_dict = {}
     for row in enrolment_details_result:
         business_id = str(getattr(row, "business_id"))
@@ -64,13 +60,16 @@ def get_enrolment_data(survey_id, business_ids_string) -> dict:
     #     '123': [{'respondent_id': 1, 'status': 'active'}, {'respondent_id': 2, 'status': 'active'}]
     #     '456': [{'respondent_id': 1, 'status': 'active'}, {'respondent_id': 3, 'status': 'active'}]
     # }
+    logger.info("Got enrolment details")
     return resulting_dict, respondent_ids_string
 
 
 def get_respondent_data(respondent_ids_string) -> dict:
+    logger.info("About to get respondent data")
     party_engine = app.party_db.engine
     respondent_details_query_text = f"SELECT * FROM partysvc.respondent r WHERE r.id IN ({respondent_ids_string}) "
     respondent_details_query = text(respondent_details_query_text)
     respondent_details_result = party_engine.execute(respondent_details_query).all()
     results_dict = {str(getattr(item, "id")): item for item in respondent_details_result}
+    logger.info("Got respondent data")
     return results_dict

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -27,7 +27,7 @@ def get_attribute_data(collection_exercise_id):
     return result_dict
 
 
-def get_enrolment_data(survey_id, business_ids_string):
+def get_enrolment_data(survey_id, business_ids_string) -> tuple[dict[str, list], str]:
     party_engine = app.party_db.engine
     # Get list of respondents for all those businesses for this survey (via enrolment table)
     # Get all the enrolments for the survey the exercise is for but only for the businesses
@@ -46,7 +46,7 @@ def get_enrolment_data(survey_id, business_ids_string):
     for row in enrolment_details_result:
         respondent_ids_string += f"'{str(getattr(row, 'respondent_id'))}', "
 
-        # slice off the tailing ', '
+    # slice off the tailing ', '
     respondent_ids_string = respondent_ids_string[:-2]
     resulting_dict = {}
     for row in enrolment_details_result:
@@ -73,3 +73,17 @@ def get_respondent_data(respondent_ids_string) -> dict:
     results_dict = {str(getattr(item, "id")): item for item in respondent_details_result}
     logger.info("Got respondent data")
     return results_dict
+
+
+def get_dashboard_enrolment_details(survey_id, business_ids_string) -> list:
+    party_engine = app.party_db.engine
+    enrolment_details_query_text = (
+        f"SELECT * "
+        f"FROM partysvc.enrolment e "
+        f"WHERE "
+        f"e.survey_id = :survey_id AND e.business_id IN ({business_ids_string}) "
+    )
+
+    enrolment_details_query = text(enrolment_details_query_text)
+    enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id).all()
+    return enrolment_details_result

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -23,7 +23,8 @@ def get_attribute_data(collection_exercise_id):
     logger.info("About to get party attributes")
     attributes_result = party_engine.execute(attributes, collection_exercise_id=collection_exercise_id).all()
     logger.info("Got party attributes")
-    return attributes_result
+    result_dict = {str(getattr(item, "business_party_uuid")): item for item in attributes_result}
+    return result_dict
 
 
 def get_enrolment_data(survey_id, business_ids_string) -> dict:
@@ -53,7 +54,7 @@ def get_enrolment_data(survey_id, business_ids_string) -> dict:
     logger.info("Got enrolment details")
     resulting_dict = {}
     for row in enrolment_details_result:
-        business_id = str(getattr(row, 'business_id'))
+        business_id = str(getattr(row, "business_id"))
         if resulting_dict.get(business_id) is None:
             resulting_dict[business_id] = [row]
         else:

--- a/rm_reporting/controllers/party_controller.py
+++ b/rm_reporting/controllers/party_controller.py
@@ -67,8 +67,7 @@ def get_enrolment_data(survey_id, business_ids_string) -> tuple[dict[str, list],
 def get_respondent_data(respondent_ids_string) -> dict:
     logger.info("About to get respondent data")
     party_engine = app.party_db.engine
-    respondent_details_query_text = f"SELECT * FROM partysvc.respondent r WHERE r.id IN ({respondent_ids_string}) "
-    respondent_details_query = text(respondent_details_query_text)
+    respondent_details_query = text(f"SELECT * FROM partysvc.respondent r WHERE r.id IN ({respondent_ids_string}) ")
     respondent_details_result = party_engine.execute(respondent_details_query).all()
     results_dict = {str(getattr(item, "id")): item for item in respondent_details_result}
     logger.info("Got respondent data")

--- a/rm_reporting/resources/info.py
+++ b/rm_reporting/resources/info.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from flask import jsonify, make_response
+from flask import jsonify
 from flask_restx import Resource
 
 from rm_reporting import api, app
@@ -22,4 +22,4 @@ class Info(Resource):
         }
         info = dict(_health_check, **info)
 
-        return make_response(jsonify(info), 200)
+        return jsonify(info)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -2,11 +2,12 @@ import io
 import logging
 
 from flask import make_response
-from flask_restx import Resource
+from flask_restx import Resource, abort
 from openpyxl import Workbook
 from structlog import wrap_logger
 
 from rm_reporting import response_chasing_api
+from rm_reporting.common.validators import parse_uuid
 from rm_reporting.controllers import case_controller, party_controller
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -16,6 +17,18 @@ logger = wrap_logger(logging.getLogger(__name__))
 class ResponseChasingDownload(Resource):
     @staticmethod
     def get(collection_exercise_id, survey_id):
+        parsed_survey_id = parse_uuid(survey_id)
+        if not parsed_survey_id:
+            logger.debug("Responses dashboard endpoint received malformed survey ID", invalid_survey_id=survey_id)
+            abort(400, "Malformed survey ID")
+
+        parsed_collection_exercise_id = parse_uuid(collection_exercise_id)
+        if not parsed_collection_exercise_id:
+            logger.debug(
+                "Responses dashboard endpoint received malformed collection exercise ID",
+                invalid_collection_exercise_id=collection_exercise_id,
+            )
+            abort(400, "Malformed collection exercise ID")
 
         output = io.BytesIO()
         wb = Workbook(write_only=True)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -18,25 +18,36 @@ class ResponseChasingDownload(Resource):
     def get(collection_exercise_id, survey_id):
 
         output = io.BytesIO()
-        wb = Workbook()
-        ws = wb.active
+        wb = Workbook(write_only=True)
+        ws = wb.create_sheet()
         ws.title = "Response Chasing Report"
 
         # Set headers
-        headers = {
-            "A1": "Survey Status",
-            "B1": "Reporting Unit Ref",
-            "C1": "Reporting Unit Name",
-            "D1": "Enrolment Status",
-            "E1": "Respondent Name",
-            "F1": "Respondent Telephone",
-            "G1": "Respondent Email",
-            "H1": "Respondent Account Status",
-        }
+        # headers = {
+        #     "A1": "Survey Status",
+        #     "B1": "Reporting Unit Ref",
+        #     "C1": "Reporting Unit Name",
+        #     "D1": "Enrolment Status",
+        #     "E1": "Respondent Name",
+        #     "F1": "Respondent Telephone",
+        #     "G1": "Respondent Email",
+        #     "H1": "Respondent Account Status",
+        # }
+        list_headers = [
+            "Survey Status",
+            "Reporting Unit Ref",
+            "Reporting Unit Name",
+            "Enrolment Status",
+            "Respondent Name",
+            "Respondent Telephone",
+            "Respondent Email",
+            "Respondent Account Status",
+        ]
+        ws.append(list_headers)
 
-        for cell, header in headers.items():
-            ws[cell] = header
-            ws.column_dimensions[cell[0]].width = len(header)
+        # for cell, header in headers.items():
+        #     ws[cell] = header
+        #     ws.column_dimensions[cell[0]].width = len(header)
 
         # Get case data (and list of ru_refs and business_ids)
         case_result = case_controller.get_case_data(collection_exercise_id)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -119,10 +119,16 @@ class ResponseChasingDownload(Resource):
             enrolment_count_for_business = 0
             for enrolment in enrolment_details_result:
                 if getattr(enrolment, "business_id") == getattr(row, "party_id"):
-                    # TODO improve this.  For now we know it's ordered by id so id - 1 gets us the right value in the
-                    # list.
-                    respondent_index = getattr(enrolment, "respondent_id") - 1
-                    respondent_details = respondent_details_result[respondent_index]
+
+                    # Get the resolved respondent details from the earlier result.  For now, we have to loop over the
+                    # list to find the right one, but we can reorganise it for easier access
+                    respondent_details = None
+                    for respondent in respondent_details_result:
+                        # We need to handle the possibility of the respondent being deleted
+                        if getattr(respondent, "id") == getattr(enrolment, "respondent_id"):
+                            respondent_details = respondent
+                            break
+
                     enrolment_status = getattr(enrolment, "status")
                     respondent_name = (
                         getattr(respondent_details, "first_name") + " " + getattr(respondent_details, "last_name")

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -116,6 +116,8 @@ class ResponseChasingDownload(Resource):
                     break
 
             # Create a row in the spreadsheet for each enrolment for this survey in the business
+            number_of_enrolments = len(enrolment_details_result)
+            enrolment_count_for_business = 0
             for enrolment in enrolment_details_result:
                 if getattr(enrolment, "business_id") == getattr(row, "party_id"):
                     # TODO improve this.  For now we know it's ordered by id so id - 1 gets us the right value in the
@@ -141,6 +143,23 @@ class ResponseChasingDownload(Resource):
                         respondent_account_status,
                     ]
                     ws.append(business)
+                    enrolment_count_for_business += 1
+
+            # If there are no enrolments for the business, we still need to report on it
+            if enrolment_count_for_business == 0:
+                business = [
+                    survey_status,
+                    ru_ref,
+                    ru_name,
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ]
+                ws.append(business)
+
+
 
         wb.active = 1
         wb.save(output)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -52,7 +52,7 @@ class ResponseChasingDownload(Resource):
         case_result = case_controller.get_case_data(collection_exercise_id)
 
         # Get all the party_ids for all the businesses that are part of the collection exercise
-        business_ids_string = ResponseChasingDownload.get_business_ids_from_case_data(case_result)
+        business_ids_string = case_controller.get_business_ids_from_case_data(case_result)
 
         # Get the attribute data for all the businesses in this collection exercise
         attributes_result = party_controller.get_attribute_data(collection_exercise_id)
@@ -123,19 +123,3 @@ class ResponseChasingDownload(Resource):
         response.headers["Content-Disposition"] = f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
         response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         return response
-
-    @staticmethod
-    def get_business_ids_from_case_data(case_result) -> str:
-        """
-        Takes a list of case results and returns a comma separated list of business_ids
-        Example output (as a string): 8a4bc9b4-1b8e-4c0f-be72-41da20b82f16, 5b3ac08f-8399-4548-b4d8-0bd2df723672
-        :param case_result:
-        :return:
-        """
-        # TODO get the values in a list in a tidier way...
-        business_ids_string = ""
-        for row in case_result:
-            business_ids_string += f"'{str(getattr(row, 'party_id'))}', "
-        # slice off the tailing ', '
-        business_ids_string = business_ids_string[:-2]
-        return business_ids_string

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -52,9 +52,9 @@ class ResponseChasingDownload(Resource):
             "WHERE collection_exercise_id = :collection_exercise_id and "
             "sample_unit_ref NOT LIKE '1111%'"
         )
-
+        logger.info("About to get case data")
         case_result = case_engine.execute(case_business_ids_query, collection_exercise_id=collection_exercise_id).all()
-
+        logger.info("Got case data")
         # Get all the party_ids for all the businesses that are part of the collection exercise
         # TODO get the values in a list in a tidier way...
         business_ids_list = []
@@ -76,8 +76,10 @@ class ResponseChasingDownload(Resource):
             f"WHERE "
             f"ba.collection_exercise = '{collection_exercise_id}'"
         )
-
+        logger.info("About to get party attributes")
         attributes_result = party_engine.execute(attributes, collection_exercise_id=collection_exercise_id).all()
+        logger.info("Got party attributes")
+
         # TODO maybe loop over it, converting it into a dict keyed by the ru_ref for easy access later on
         # Get list of respondents for all those businesses for this survey (via enrolment table)
         # Get all the enrolments for the survey the exercise is for but only for the businesses
@@ -91,7 +93,9 @@ class ResponseChasingDownload(Resource):
         enrolment_details_query = text(enrolment_details_query_text)
         # TODO maybe loop over it, converting it into a dict keyed by the ru_ref for easy access later on as theres a
         # lot of wasted work looping over all the results again and again
+        logger.info("About to get enrolment details")
         enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id).all()
+        logger.info("Got enrolment details")
         respondent_ids_string = ""
         for row in enrolment_details_result:
             respondent_ids_string += f"'{str(getattr(row, 'respondent_id'))}', "
@@ -106,7 +110,9 @@ class ResponseChasingDownload(Resource):
         respondent_details_result = party_engine.execute(respondent_details_query).all()
 
         # Loop over all the cases, filling in the blanks along the way and add each row to the spreadsheet
+        logger.info("About to loop over all the data")
         for row in case_result:
+            logger.info("Dealing with ru", ru_ref=getattr(row, "sample_unit_ref"))
             survey_status = getattr(row, "status")
             ru_ref = getattr(row, "sample_unit_ref")
             ru_name = ""
@@ -118,6 +124,7 @@ class ResponseChasingDownload(Resource):
             # Create a row in the spreadsheet for each enrolment for this survey in the business
             enrolment_count_for_business = 0
             for enrolment in enrolment_details_result:
+                logger.info("Dealing with enrolments for business", business_id=getattr(enrolment, "business_id"))
                 if getattr(enrolment, "business_id") == getattr(row, "party_id"):
 
                     # Get the resolved respondent details from the earlier result.  For now, we have to loop over the
@@ -149,6 +156,7 @@ class ResponseChasingDownload(Resource):
                     ]
                     ws.append(business)
                     enrolment_count_for_business += 1
+                    logger.info("Added row to the table")
 
             # If there are no enrolments for the business, we still need to report on it
             if enrolment_count_for_business == 0:
@@ -163,10 +171,12 @@ class ResponseChasingDownload(Resource):
                     "",
                 ]
                 ws.append(business)
+                logger.info("Added empty row to the table")
 
         wb.active = 1
         wb.save(output)
         wb.close()
+        logger.info("Finished putting together spreadsheet")
 
         response = make_response(output.getvalue(), 200)
         response.headers["Content-Disposition"] = f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -1,16 +1,12 @@
-import csv
 import io
 import logging
-from datetime import datetime
 
 from flask import make_response
 from flask_restx import Resource
 from openpyxl import Workbook
-from sqlalchemy import text
-from sqlalchemy.exc import SQLAlchemyError
 from structlog import wrap_logger
 
-from rm_reporting import app, response_chasing_api
+from rm_reporting import response_chasing_api
 from rm_reporting.controllers import case_controller, party_controller
 
 logger = wrap_logger(logging.getLogger(__name__))
@@ -112,7 +108,7 @@ class ResponseChasingDownload(Resource):
                     "",
                 ]
                 ws.append(business)
-
+        logger.info("Finished looping over cases")
         wb.active = 1
         wb.save(output)
         wb.close()
@@ -121,70 +117,4 @@ class ResponseChasingDownload(Resource):
         response = make_response(output.getvalue(), 200)
         response.headers["Content-Disposition"] = f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
         response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        return response
-
-
-@response_chasing_api.route("/download-social-mi/<collection_exercise_id>")
-class SocialMIDownload(Resource):
-    @staticmethod
-    def get(collection_exercise_id):
-        output = io.StringIO()
-
-        # Set headers
-        headers = [
-            "Sample Reference",
-            "Status",
-            "Status Event",
-            "Address Line 1",
-            "Address Line 2",
-            "Locality",
-            "Town Name",
-            "Postcode",
-            "Country",
-        ]
-
-        datestr = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-
-        engine = app.db.engine
-
-        case_status = text(
-            "SELECT cg.sampleunitref, cg.status, "
-            "(SELECT cat.shortdescription "
-            "FROM casesvc.caseevent ce "
-            "JOIN casesvc.category cat "
-            "ON ce.categoryfk = cat.categorypk "
-            "WHERE ce.casefk = c.casepk "
-            "AND cat.shortdescription ~ '^[[:digit:]]*$' "
-            "ORDER BY ce.createddatetime DESC LIMIT 1), "
-            "attributes->> 'ADDRESS_LINE1' AS address_line_1, "
-            "attributes->> 'ADDRESS_LINE2' AS address_line_2, "
-            "attributes->> 'LOCALITY' AS locality, "
-            "attributes->> 'TOWN_NAME' AS town_name, "
-            "attributes->> 'POSTCODE' AS postcode, "
-            "attributes->> 'COUNTRY' AS country "
-            "FROM casesvc.case c "
-            "JOIN casesvc.casegroup cg "
-            "ON c.casegroupfk = cg.casegrouppk "
-            "JOIN samplesvc.sampleattributes sa "
-            "ON CONCAT(attributes->> 'TLA', '' , attributes->> 'REFERENCE') = cg.sampleunitref "
-            "WHERE c.sampleunittype = 'H' AND cg.collectionexerciseid = :collection_exercise_id"
-        )
-
-        try:
-            case_details = engine.execute(case_status, collection_exercise_id=collection_exercise_id)
-        except SQLAlchemyError:
-            logger.exception("SQL Alchemy query failed")
-            raise
-
-        my_data = [headers]
-        my_data.extend(case_details)
-
-        writer = csv.writer(output)
-        writer.writerows(my_data)
-
-        response = make_response(output.getvalue(), 200)
-        response.headers["Content-Disposition"] = (
-            f"attachment; filename=social_mi_report_{collection_exercise_id}" f"_{datestr}.csv"
-        )
-        response.headers["Content-type"] = "text/csv"
         return response

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -23,17 +23,7 @@ class ResponseChasingDownload(Resource):
         ws.title = "Response Chasing Report"
 
         # Set headers
-        # headers = {
-        #     "A1": "Survey Status",
-        #     "B1": "Reporting Unit Ref",
-        #     "C1": "Reporting Unit Name",
-        #     "D1": "Enrolment Status",
-        #     "E1": "Respondent Name",
-        #     "F1": "Respondent Telephone",
-        #     "G1": "Respondent Email",
-        #     "H1": "Respondent Account Status",
-        # }
-        list_headers = [
+        headers = [
             "Survey Status",
             "Reporting Unit Ref",
             "Reporting Unit Name",
@@ -43,11 +33,7 @@ class ResponseChasingDownload(Resource):
             "Respondent Email",
             "Respondent Account Status",
         ]
-        ws.append(list_headers)
-
-        # for cell, header in headers.items():
-        #     ws[cell] = header
-        #     ws.column_dimensions[cell[0]].width = len(header)
+        ws.append(headers)
 
         # Get case data (and list of ru_refs and business_ids)
         case_result = case_controller.get_case_data(collection_exercise_id)
@@ -69,7 +55,6 @@ class ResponseChasingDownload(Resource):
         # Loop over all the cases, filling in the blanks along the way and add each row to the spreadsheet
         logger.info("About to loop over all the data")
         for row in case_result:
-            logger.info("Dealing with ru", ru_ref=getattr(row, "sample_unit_ref"))
             survey_status = getattr(row, "status")
             ru_ref = getattr(row, "sample_unit_ref")
             attribute_data = attributes_result[str(getattr(row, "party_id"))]

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -31,6 +31,9 @@ class ResponseChasingDownload(Resource):
             abort(400, "Malformed collection exercise ID")
 
         output = io.BytesIO()
+        # A write_only workbook is a lot more performant at writing a large amount of data if you don't mind giving up
+        # some functionality.  We're not reading or doing anything fancy with this spreadsheet as we make it, so it's
+        # functionally no different.
         wb = Workbook(write_only=True)
         ws = wb.create_sheet()
         ws.title = "Response Chasing Report"

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -116,7 +116,6 @@ class ResponseChasingDownload(Resource):
                     break
 
             # Create a row in the spreadsheet for each enrolment for this survey in the business
-            number_of_enrolments = len(enrolment_details_result)
             enrolment_count_for_business = 0
             for enrolment in enrolment_details_result:
                 if getattr(enrolment, "business_id") == getattr(row, "party_id"):
@@ -158,8 +157,6 @@ class ResponseChasingDownload(Resource):
                     "",
                 ]
                 ws.append(business)
-
-
 
         wb.active = 1
         wb.save(output)

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -57,8 +57,9 @@ class ResponseChasingDownload(Resource):
 
         attributes_result = party_controller.get_attribute_data(collection_exercise_id)
 
-        enrolment_details_result, respondent_ids_string = party_controller.get_enrolment_data(survey_id,
-                                                                                              business_ids_string)
+        enrolment_details_result, respondent_ids_string = party_controller.get_enrolment_data(
+            survey_id, business_ids_string
+        )
 
         respondent_details_result = party_controller.get_respondent_data(respondent_ids_string)
 
@@ -68,14 +69,11 @@ class ResponseChasingDownload(Resource):
             logger.info("Dealing with ru", ru_ref=getattr(row, "sample_unit_ref"))
             survey_status = getattr(row, "status")
             ru_ref = getattr(row, "sample_unit_ref")
-            ru_name = ""
-            for business in attributes_result:
-                if getattr(business, "business_party_uuid") == getattr(row, "party_id"):
-                    ru_name = getattr(business, "business_name")
-                    break
+            attribute_data = attributes_result[str(getattr(row, "party_id"))]
+            ru_name = getattr(attribute_data, "business_name")
 
             # Create a row in the spreadsheet for each enrolment for this survey in the business
-            business_enrolments = enrolment_details_result.get(str(getattr(row, 'party_id')), [])
+            business_enrolments = enrolment_details_result.get(str(getattr(row, "party_id")), [])
             enrolment_count_for_business = 0
             for enrolment in business_enrolments:
                 respondent_details = respondent_details_result[str(getattr(enrolment, "respondent_id"))]

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -78,12 +78,11 @@ def get_report_figures(survey_id, collection_exercise_id):
     )
 
     enrolment_details_query = text(enrolment_details_query_text)
-    enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id)
-    blah = enrolment_details_result.all()
+    enrolment_details_result = party_engine.execute(enrolment_details_query, survey_id=survey_id).all()
 
     pending = 0
     enabled = 0
-    for row in blah:
+    for row in enrolment_details_result:
         if getattr(row, "status") == "ENABLED":
             enabled += 1
         if getattr(row, "status") == "PENDING":

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -15,14 +15,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 
 def get_report_figures(survey_id, collection_exercise_id):
     logger.info("Getting report figures", survey_id=survey_id, collection_exercise_id=collection_exercise_id)
-    result_dict = {
-        "inProgress": 0,
-        "accountsPending": 0,
-        "accountsEnrolled": 0,
-        "notStarted": 0,
-        "completed": 0,
-        "sampleSize": 0,
-    }
+    result_dict = {}
 
     # Get all cases for a collection exercise
     case_result = case_controller.get_exercise_completion_stats(collection_exercise_id)
@@ -34,10 +27,10 @@ def get_report_figures(survey_id, collection_exercise_id):
     result_dict["completed"] = getattr(case_result[0], "Complete")
 
     # Get all the party_ids for all the businesses that are part of the collection exercise
-    business_ids_string = case_controller.get_all_business_ids_for_collection_exercise(collection_exercise_id)
+    business_ids = case_controller.get_all_business_ids_for_collection_exercise(collection_exercise_id)
 
     # Get all the enrolments for the survey the exercise is for but only for the businesses
-    enrolment_details_result = party_controller.get_dashboard_enrolment_details(survey_id, business_ids_string)
+    enrolment_details_result = party_controller.get_enrolment_data(survey_id, business_ids)
 
     pending = 0
     enabled = 0

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -43,7 +43,6 @@ def get_report_figures(survey_id, collection_exercise_id):
     result_dict["inProgress"] = getattr(case_result[0], "In Progress")
     result_dict["notStarted"] = getattr(case_result[0], "Not Started")
     result_dict["completed"] = getattr(case_result[0], "Complete")
-    logger.info(case_result)
     # Should we filter out the 1111* ones?  Maybe we get them in the initial search then filter them out and do some
     # logging saying 'filtered out x number of test reporting units to make it obvious'
 

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -51,17 +51,14 @@ def get_report_figures(survey_id, collection_exercise_id):
 class ResponseDashboard(Resource):
     @staticmethod
     def get(survey_id, collection_exercise_id):
-
-        parsed_survey_id = parse_uuid(survey_id)
-        if not parsed_survey_id:
-            logger.debug("Responses dashboard endpoint received malformed survey ID", invalid_survey_id=survey_id)
+        if not parse_uuid(survey_id):
+            logger.debug("Responses dashboard endpoint received malformed survey ID", survey_id=survey_id)
             abort(400, "Malformed survey ID")
 
-        parsed_collection_exercise_id = parse_uuid(collection_exercise_id)
-        if not parsed_collection_exercise_id:
+        if not parse_uuid(collection_exercise_id):
             logger.debug(
                 "Responses dashboard endpoint received malformed collection exercise ID",
-                invalid_collection_exercise_id=collection_exercise_id,
+                collection_exercise_id=collection_exercise_id,
             )
             abort(400, "Malformed collection exercise ID")
 

--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -26,6 +26,8 @@ def get_report_figures(survey_id, collection_exercise_id):
 
     # Get all cases for a collection exercise
     case_result = case_controller.get_exercise_completion_stats(collection_exercise_id)
+    if getattr(case_result[0], "Sample Size") == 0:
+        raise NoDataException
     result_dict["sampleSize"] = getattr(case_result[0], "Sample Size")
     result_dict["inProgress"] = getattr(case_result[0], "In Progress")
     result_dict["notStarted"] = getattr(case_result[0], "Not Started")

--- a/run.py
+++ b/run.py
@@ -17,4 +17,4 @@ if __name__ == "__main__":
     logger_initial_config(service_name="rm_reporting", log_level=app.config["LOGGING_LEVEL"])
 
     logger.info(f"Starting listening on port {app.config['PORT']}")
-    app.run(debug=app.config["INFO"], host="0.0.0.0", port=int(app.config["PORT"]))
+    app.run(debug=app.config["DEBUG"], host="0.0.0.0", port=int(app.config["PORT"]))

--- a/test/controllers/case_controller.py
+++ b/test/controllers/case_controller.py
@@ -1,0 +1,32 @@
+from unittest import TestCase
+from uuid import UUID
+
+from rm_reporting.controllers import case_controller
+
+
+class Row(object):
+    """
+    This is going represent a row returned from SqlAlchemy.  It's not a true representation, but creating a LegacyRow
+    in a matching format is incredibly difficult.  We'll just setattr what we need against it, and then it becomes a
+    close enough approximation
+    """
+
+    pass
+
+
+class TestCaseController(TestCase):
+    def test_get_business_ids_from_case_data(self):
+        row_1 = Row()
+        row_2 = Row()
+        row_3 = Row()
+        setattr(row_1, "party_id", UUID("baefaaef-a2fa-48bc-a2c0-2d58e202253d"))
+        setattr(row_2, "party_id", UUID("03abc990-4e0f-459e-a3ca-d505fda19299"))
+        setattr(row_3, "party_id", UUID("e2163f5c-c972-435e-8127-5845a4176358"))
+        expected_output = (
+            "'baefaaef-a2fa-48bc-a2c0-2d58e202253d', "
+            "'03abc990-4e0f-459e-a3ca-d505fda19299', "
+            "'e2163f5c-c972-435e-8127-5845a4176358'"
+        )
+        test_input = [row_1, row_2, row_3]
+        test_output = case_controller.get_business_ids_from_case_data(test_input)
+        self.assertEqual(expected_output, test_output)

--- a/test/controllers/party_controller.py
+++ b/test/controllers/party_controller.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+from rm_reporting.controllers import party_controller
+
+survey_id = "0b1e95dd-c84b-4ce3-a6b1-fe6802e4bda0"
+
+
+class TestPartyController(TestCase):
+    def test_get_enrolment_data_empty_string(self):
+        test_business_ids = ""
+        expected_output = []
+        test_output = party_controller.get_enrolment_data(survey_id, test_business_ids)
+        self.assertEqual(expected_output, test_output)
+
+    def test_get_respondent_ids_from_enrolment_data_empty_string(self):
+        test_input = []
+        expected_output = ""
+        test_output = party_controller.get_respondent_ids_from_enrolment_data(test_input)
+        self.assertEqual(expected_output, test_output)
+
+    def test_get_respondent_data_empty_string(self):
+        test_input = ""
+        expected_output = {}
+        test_output = party_controller.get_respondent_data(test_input)
+        self.assertEqual(expected_output, test_output)

--- a/test/resources/test_response_chasing.py
+++ b/test/resources/test_response_chasing.py
@@ -1,0 +1,27 @@
+import json
+from unittest import TestCase
+
+from rm_reporting import app
+
+
+class TestResponseChasing(TestCase):
+    def setUp(self):
+        self.test_client = app.test_client()
+
+    def test_dashboard_report_malformed_collection_exercise_id(self):
+        response = self.test_client.get(
+            "/reporting-api/v1/response-chasing/download-report/not-a-valid-uuid/57586798-74e3-49fd-93da-a782ec5f5129"
+        )
+        error_response = json.loads(response.data)["message"]
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(error_response, "Malformed collection exercise ID")
+
+    def test_dashboard_report_malformed_survey_id(self):
+        response = self.test_client.get(
+            "/reporting-api/v1/response-chasing/download-report/33db9feb-bed0-46e8-bcb1-3a0373224cd3/not-a-valid-uuid"
+        )
+        error_response = json.loads(response.data)["message"]
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(error_response, "Malformed survey ID")

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -1,5 +1,5 @@
 import json
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from rm_reporting import app
 
@@ -8,48 +8,48 @@ class TestResponseDashboard(TestCase):
     def setUp(self):
         self.test_client = app.test_client()
 
-    @mock.patch("rm_reporting.app.db")
-    def test_dashboard_report_success(self, mock_db):
-        mock_db.engine.execute.return_value.first.return_value = {
-            "Sample Size": 100,
-            "Total Enrolled": 50,
-            "Total Pending": 10,
-            "Not Started": 70,
-            "In Progress": 20,
-            "Complete": 10,
-        }
-        response = self.test_client.get(
-            "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
-            "/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3"
-        )
-        response_dict = json.loads(response.data)
+    # @mock.patch("rm_reporting.app.db")
+    # def test_dashboard_report_success(self, mock_db):
+    #     mock_db.engine.execute.return_value.first.return_value = {
+    #         "Sample Size": 100,
+    #         "Total Enrolled": 50,
+    #         "Total Pending": 10,
+    #         "Not Started": 70,
+    #         "In Progress": 20,
+    #         "Complete": 10,
+    #     }
+    #     response = self.test_client.get(
+    #         "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
+    #         "/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3"
+    #     )
+    #     response_dict = json.loads(response.data)
+    #
+    #     self.assertEqual(200, response.status_code)
+    #     self.assertEqual(100, response_dict["report"]["sampleSize"])
+    #     self.assertEqual(50, response_dict["report"]["accountsEnrolled"])
+    #     self.assertEqual(10, response_dict["report"]["accountsPending"])
+    #     self.assertEqual(10, response_dict["report"]["completed"])
+    #     self.assertEqual(20, response_dict["report"]["inProgress"])
+    #     self.assertEqual(70, response_dict["report"]["notStarted"])
 
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(100, response_dict["report"]["sampleSize"])
-        self.assertEqual(50, response_dict["report"]["accountsEnrolled"])
-        self.assertEqual(10, response_dict["report"]["accountsPending"])
-        self.assertEqual(10, response_dict["report"]["completed"])
-        self.assertEqual(20, response_dict["report"]["inProgress"])
-        self.assertEqual(70, response_dict["report"]["notStarted"])
-
-    @mock.patch("rm_reporting.app.db")
-    def test_dashboard_report_invalid_id(self, mock_db):
-        mock_db.engine.execute.return_value.first.return_value = {
-            "Sample Size": 100,
-            "Total Enrolled": 50,
-            "Total Pending": 10,
-            "Not Started": 100,
-            "In Progress": 30,
-            "Complete": None,
-        }
-        response = self.test_client.get(
-            "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
-            "/collection-exercise/00000000-0000-0000-0000-000000000000"
-        )
-        error_response = json.loads(response.data)["message"]
-
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(error_response, "Invalid collection exercise or survey ID")
+    # @mock.patch("rm_reporting.app.db")
+    # def test_dashboard_report_invalid_id(self, mock_db):
+    #     mock_db.engine.execute.return_value.first.return_value = {
+    #         "Sample Size": 100,
+    #         "Total Enrolled": 50,
+    #         "Total Pending": 10,
+    #         "Not Started": 100,
+    #         "In Progress": 30,
+    #         "Complete": None,
+    #     }
+    #     response = self.test_client.get(
+    #         "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
+    #         "/collection-exercise/00000000-0000-0000-0000-000000000000"
+    #     )
+    #     error_response = json.loads(response.data)["message"]
+    #
+    #     self.assertEqual(response.status_code, 404)
+    #     self.assertEqual(error_response, "Invalid collection exercise or survey ID")
 
     def test_dashboard_report_malformed_collection_exercise_id(self):
         response = self.test_client.get(

--- a/test/resources/test_responses_dashboard.py
+++ b/test/resources/test_responses_dashboard.py
@@ -1,5 +1,5 @@
 import json
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from rm_reporting import app
 
@@ -8,29 +8,29 @@ class TestResponseDashboard(TestCase):
     def setUp(self):
         self.test_client = app.test_client()
 
-    # @mock.patch("rm_reporting.app.db")
-    # def test_dashboard_report_success(self, mock_db):
-    #     mock_db.engine.execute.return_value.first.return_value = {
-    #         "Sample Size": 100,
-    #         "Total Enrolled": 50,
-    #         "Total Pending": 10,
-    #         "Not Started": 70,
-    #         "In Progress": 20,
-    #         "Complete": 10,
-    #     }
-    #     response = self.test_client.get(
-    #         "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
-    #         "/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3"
-    #     )
-    #     response_dict = json.loads(response.data)
-    #
-    #     self.assertEqual(200, response.status_code)
-    #     self.assertEqual(100, response_dict["report"]["sampleSize"])
-    #     self.assertEqual(50, response_dict["report"]["accountsEnrolled"])
-    #     self.assertEqual(10, response_dict["report"]["accountsPending"])
-    #     self.assertEqual(10, response_dict["report"]["completed"])
-    #     self.assertEqual(20, response_dict["report"]["inProgress"])
-    #     self.assertEqual(70, response_dict["report"]["notStarted"])
+    @mock.patch("rm_reporting.resources.responses_dashboard.get_report_figures")
+    def test_dashboard_report_success(self, mock_reporting_figures):
+        mock_reporting_figures.return_value = {
+            "sampleSize": 100,
+            "accountsEnrolled": 50,
+            "accountsPending": 10,
+            "notStarted": 70,
+            "inProgress": 20,
+            "completed": 10,
+        }
+        response = self.test_client.get(
+            "/reporting-api/v1/response-dashboard/survey/57586798-74e3-49fd-93da-a782ec5f5129"
+            "/collection-exercise/33db9feb-bed0-46e8-bcb1-3a0373224cd3"
+        )
+        response_dict = json.loads(response.data)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(100, response_dict["report"]["sampleSize"])
+        self.assertEqual(50, response_dict["report"]["accountsEnrolled"])
+        self.assertEqual(10, response_dict["report"]["accountsPending"])
+        self.assertEqual(10, response_dict["report"]["completed"])
+        self.assertEqual(20, response_dict["report"]["inProgress"])
+        self.assertEqual(70, response_dict["report"]["notStarted"])
 
     # @mock.patch("rm_reporting.app.db")
     # def test_dashboard_report_invalid_id(self, mock_db):


### PR DESCRIPTION
# What and why?

The previous version of the reporting app used the reporting database.  It was slow and difficult to maintain as the way to query the database was done via one giant multi database spanning sql query.

This new way uses the read replicas to access only the databases it needs (party and case) which makes it more obvious what is accessing what (for context, the reporting database is a database that uses a foreign data wrapper to treat all of our 10-ish databases for our services as 1 big database).  As this is the only thing using it, it also allows us to remove the reporting database at some point too.

The way the dashboard and the spreadsheets are generated should be easier to maintain as as now make a few smaller database calls to get what we need before compiling that data into something usable.  It should also be easier to test.

This PR will be the first of 2 parts to keep it manageable.  This one gets the functionality implemented, config set and the code looking pretty good.  There will be another one that adds a few more unit tests, docstrings and tidies up the functions to make sure their inputs and outputs make sense

# How to test?

- Deploy environment and run test to seed data
- Either:
    - run locally (using `ras pf` to port forward the database) and hit the endpoints using postman or curl. or
    - Deploy to your k8s environment, but then modify the deployment to get the database uri's in the right state.  Because spinnaker deploys the latest helm chart, it's tricky to get it to work

# Trello
