### PR TITLE
 RAS-940: Questionnaire Completion Rate Information

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker
 
@@ -165,18 +165,11 @@ jobs:
           cp $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-latest.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/
 
-      - uses: actions/create-release@v1
+      - name: Publish Release
         if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.version }}
-          release_name: ${{ env.version }}
-          body: |
-            Automated release
-            ${{ env.version }}
-          draft: false
-          prerelease: false
+        run: gh release create ${{ env.version }} --title ${{ env.version }} --notes ${{ env.version }}
 
       - name: CD hook
         if: github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint-check:
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8
 
-test:
+test: lint-check
 	pipenv run pytest --cov=rm_reporting --cov-report term-missing
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint-check:
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8
 
-test: lint-check
+test:
 	pipenv run pytest --cov=rm_reporting --cov-report term-missing
 
 start:

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -19,10 +19,14 @@ def get_case_data(collection_exercise_id: str) -> list:
     logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
-        "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
+        "SELECT party_id, sample_unit_ref, status, cast(change_state_timestamp as varchar(30)) "
         "FROM casesvc.casegroup "
-        "WHERE collection_exercise_id = :collection_exercise_id "
-        "ORDER BY sample_unit_ref, status"
+        "WHERE collection_exercise_id = 'a2e47f5c-c517-4fea-ba5b-8b0e991c1c8b' "
+        "ORDER BY sample_unit_ref, status "
+        # "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
+        # "FROM casesvc.casegroup "
+        # "WHERE collection_exercise_id = :collection_exercise_id "
+        # "ORDER BY sample_unit_ref, status"
     )
 
     with case_engine.begin() as conn:

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -19,14 +19,14 @@ def get_case_data(collection_exercise_id: str) -> list:
     logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
-        "SELECT party_id, sample_unit_ref, status, cast(change_state_timestamp as varchar(30)) "
-        "FROM casesvc.casegroup "
-        "WHERE collection_exercise_id = 'a2e47f5c-c517-4fea-ba5b-8b0e991c1c8b' "
-        "ORDER BY sample_unit_ref, status "
-        # "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
+        # "SELECT party_id, sample_unit_ref, status, cast(change_state_timestamp as varchar(30)) "
         # "FROM casesvc.casegroup "
-        # "WHERE collection_exercise_id = :collection_exercise_id "
-        # "ORDER BY sample_unit_ref, status"
+        # "WHERE collection_exercise_id = 'a2e47f5c-c517-4fea-ba5b-8b0e991c1c8b' "
+        # "ORDER BY sample_unit_ref, status "
+        "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
+        "FROM casesvc.casegroup "
+        "WHERE collection_exercise_id = :collection_exercise_id "
+        "ORDER BY sample_unit_ref, status"
     )
 
     with case_engine.begin() as conn:

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -19,10 +19,6 @@ def get_case_data(collection_exercise_id: str) -> list:
     logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
-        # "SELECT party_id, sample_unit_ref, status, cast(change_state_timestamp as varchar(30)) "
-        # "FROM casesvc.casegroup "
-        # "WHERE collection_exercise_id = 'a2e47f5c-c517-4fea-ba5b-8b0e991c1c8b' "
-        # "ORDER BY sample_unit_ref, status "
         "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
         "FROM casesvc.casegroup "
         "WHERE collection_exercise_id = :collection_exercise_id "

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -19,7 +19,7 @@ def get_case_data(collection_exercise_id: str) -> list:
     logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
-        "SELECT party_id, sample_unit_ref, status "
+        "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
         "FROM casesvc.casegroup "
         "WHERE collection_exercise_id = :collection_exercise_id "
         "ORDER BY sample_unit_ref, status"

--- a/rm_reporting/controllers/case_controller.py
+++ b/rm_reporting/controllers/case_controller.py
@@ -19,7 +19,7 @@ def get_case_data(collection_exercise_id: str) -> list:
     logger.info("About to get case data", collection_exercise_id=collection_exercise_id)
     case_engine = app.case_db.engine
     case_business_ids_query = text(
-        "SELECT party_id, sample_unit_ref, status, change_state_timestamp "
+        "SELECT party_id, sample_unit_ref, status, status_change_timestamp "
         "FROM casesvc.casegroup "
         "WHERE collection_exercise_id = :collection_exercise_id "
         "ORDER BY sample_unit_ref, status"

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -1,5 +1,4 @@
 import csv
-from datetime import datetime
 import io
 import logging
 from typing import IO, Callable
@@ -7,6 +6,8 @@ from uuid import UUID
 
 from openpyxl import Workbook
 from structlog import wrap_logger
+
+from datetime import datetime
 
 from rm_reporting.controllers.case_controller import (
     get_business_ids_from_case_data,

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -1,7 +1,6 @@
 import csv
 import io
 import logging
-from datetime import datetime
 from typing import IO, Callable
 from uuid import UUID
 

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -66,8 +66,9 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
-        status_change_timestamp = datetime.strftime(datetime.strptime(getattr(case, "change_state_timestamp"),
-                                                                      "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S")
+        status_change_timestamp = datetime.strftime(
+            datetime.strptime(getattr(case, "change_state_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
+        )
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
         print("Datetime: " + str(status_change_timestamp))

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -1,4 +1,5 @@
 import csv
+from datetime import datetime
 import io
 import logging
 from typing import IO, Callable
@@ -21,7 +22,6 @@ from rm_reporting.controllers.party_controller import (
 
 logger = wrap_logger(logging.getLogger(__name__))
 
-
 COLUMN_TITLES = [
     "Survey Status",
     "Reporting Unit Ref",
@@ -31,7 +31,7 @@ COLUMN_TITLES = [
     "Respondent Telephone",
     "Respondent Email",
     "Respondent Account Status",
-    "Time of Status Change",
+    "STtatus Change Timestamp",
 ]
 
 
@@ -66,8 +66,11 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
-        status_change_time = str(getattr(case, "change_state_timestamp"))
+        status_change_timestamp = datetime.strftime(datetime.strptime(getattr(case, "change_state_timestamp"),
+                                                                      "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S")
+
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
+        print("Datetime: " + str(status_change_timestamp))
 
         if respondents_enrolled_for_business:
             for enrolment in respondents_enrolled_for_business:
@@ -89,7 +92,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
                     respondent_telephone,
                     respondent_email,
                     respondent_account_status,
-                    status_change_time,
+                    status_change_timestamp,
                 ]
                 append_function(document_object, row)
         else:

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -66,8 +66,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
-        status_change_time = getattr(case, "change_state_timestamp")
-        print("Checking time: " + status_change_time)
+        status_change_time = str(getattr(case, "change_state_timestamp"))
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
 
         if respondents_enrolled_for_business:

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -69,7 +69,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         if getattr(case, "status_change_timestamp"):
             status_change_timestamp = datetime.strftime(
                 datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"),
-                "%Y-%m-%d %H:%M:%S"
+                "%Y-%m-%d %H:%M:%S",
             )
         else:
             status_change_timestamp = ""

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -68,9 +68,9 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_name = getattr(business_attributes, "business_name")
         if getattr(case, "status_change_timestamp"):
             status_change_timestamp = datetime.strftime(
-                datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"),
-                "%Y-%m-%d %H:%M:%S",
-            )
+                datetime.strptime(str(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"),
+                                  "%Y-%m-%d %H:%M:%S"
+                                  ))
         else:
             status_change_timestamp = ""
 

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -66,9 +66,12 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
-        status_change_timestamp = datetime.strftime(
-            datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
-        )
+        if getattr(case, "status_change_timestamp"):
+            status_change_timestamp = datetime.strftime(
+                datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
+            )
+        else:
+            status_change_timestamp = ""
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
         print("Datetime: " + str(status_change_timestamp))

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -67,11 +67,9 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
         if getattr(case, "status_change_timestamp"):
-            status_change_timestamp = datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z")
-
-            formatted_status_change_timestamp = datetime.strftime(status_change_timestamp,"%Y-%m-%d %H:%M:%S")
+            status_change_timestamp = datetime.strftime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S")
         else:
-            formatted_status_change_timestamp = ""
+            status_change_timestamp = ""
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
         print("Datetime: " + str(status_change_timestamp))
@@ -96,7 +94,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
                     respondent_telephone,
                     respondent_email,
                     respondent_account_status,
-                    formatted_status_change_timestamp,
+                    status_change_timestamp,
                 ]
                 append_function(document_object, row)
         else:

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -31,7 +31,7 @@ COLUMN_TITLES = [
     "Respondent Telephone",
     "Respondent Email",
     "Respondent Account Status",
-    "STtatus Change Timestamp",
+    "Status Change Timestamp",
 ]
 
 

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -67,7 +67,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
         status_change_timestamp = datetime.strftime(
-            datetime.strptime(getattr(case, "change_state_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
+            datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
         )
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -1,13 +1,12 @@
 import csv
 import io
 import logging
+from datetime import datetime
 from typing import IO, Callable
 from uuid import UUID
 
 from openpyxl import Workbook
 from structlog import wrap_logger
-
-from datetime import datetime
 
 from rm_reporting.controllers.case_controller import (
     get_business_ids_from_case_data,

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -68,7 +68,8 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_name = getattr(business_attributes, "business_name")
         if getattr(case, "status_change_timestamp"):
             status_change_timestamp = datetime.strftime(
-                datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"), "%Y-%m-%d %H:%M:%S"
+                datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"),
+                "%Y-%m-%d %H:%M:%S"
             )
         else:
             status_change_timestamp = ""

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -31,7 +31,7 @@ COLUMN_TITLES = [
     "Respondent Telephone",
     "Respondent Email",
     "Respondent Account Status",
-    "Respondent Account Status Change Time",
+    "Time of Status Change",
 ]
 
 

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -66,7 +66,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
-        status_change_time = getattr(case, "status_change_time")
+        status_change_time = getattr(case, "change_state_timestamp")
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
 

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import logging
+from datetime import datetime
 from typing import IO, Callable
 from uuid import UUID
 
@@ -67,7 +68,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
         status_change_time = getattr(case, "change_state_timestamp")
-
+        print("Checking time: " + status_change_time)
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
 
         if respondents_enrolled_for_business:

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -67,12 +67,11 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
         if getattr(case, "status_change_timestamp"):
-            status_change_timestamp = datetime.strftime(
-                datetime.strptime(str(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z"),
-                                  "%Y-%m-%d %H:%M:%S"
-                                  ))
+            status_change_timestamp = datetime.strptime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S.%f %z")
+
+            formatted_status_change_timestamp = datetime.strftime(status_change_timestamp,"%Y-%m-%d %H:%M:%S")
         else:
-            status_change_timestamp = ""
+            formatted_status_change_timestamp = ""
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
         print("Datetime: " + str(status_change_timestamp))
@@ -97,7 +96,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
                     respondent_telephone,
                     respondent_email,
                     respondent_account_status,
-                    status_change_timestamp,
+                    formatted_status_change_timestamp,
                 ]
                 append_function(document_object, row)
         else:

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -31,6 +31,7 @@ COLUMN_TITLES = [
     "Respondent Telephone",
     "Respondent Email",
     "Respondent Account Status",
+    "Respondent Account Status Change Time",
 ]
 
 
@@ -65,6 +66,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         sample_unit_ref = getattr(case, "sample_unit_ref")
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
+        status_change_time = getattr(case, "status_change_time")
 
         respondents_enrolled_for_business = businesses_enrolled_map.get(str(getattr(case, "party_id")), [])
 
@@ -88,6 +90,7 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
                     respondent_telephone,
                     respondent_email,
                     respondent_account_status,
+                    status_change_time,
                 ]
                 append_function(document_object, row)
         else:

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -31,15 +31,15 @@ class ResponseChasingDownload(Resource):
 
         if document_type == "xslx":
             response = make_response(create_xslx_report(collection_exercise_id, survey_id).getvalue(), 200)
-            response.headers["Content-Disposition"] = (
-                f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
-            )
+            response.headers[
+                "Content-Disposition"
+            ] = f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
             response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         elif document_type == "csv":
             response = make_response(create_csv_report(collection_exercise_id, survey_id).getvalue())
-            response.headers["Content-Disposition"] = (
-                f"attachment; filename=response_chasing_{collection_exercise_id}.csv"
-            )
+            response.headers[
+                "Content-Disposition"
+            ] = f"attachment; filename=response_chasing_{collection_exercise_id}.csv"
             response.headers["Content-type"] = "text/csv"
         else:
             abort(400, "Document type not supported")

--- a/rm_reporting/resources/response_chasing.py
+++ b/rm_reporting/resources/response_chasing.py
@@ -31,15 +31,15 @@ class ResponseChasingDownload(Resource):
 
         if document_type == "xslx":
             response = make_response(create_xslx_report(collection_exercise_id, survey_id).getvalue(), 200)
-            response.headers[
-                "Content-Disposition"
-            ] = f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
+            response.headers["Content-Disposition"] = (
+                f"attachment; filename=response_chasing_{collection_exercise_id}.xlsx"
+            )
             response.headers["Content-type"] = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         elif document_type == "csv":
             response = make_response(create_csv_report(collection_exercise_id, survey_id).getvalue())
-            response.headers[
-                "Content-Disposition"
-            ] = f"attachment; filename=response_chasing_{collection_exercise_id}.csv"
+            response.headers["Content-Disposition"] = (
+                f"attachment; filename=response_chasing_{collection_exercise_id}.csv"
+            )
             response.headers["Content-type"] = "text/csv"
         else:
             abort(400, "Document type not supported")

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 
 BUSINESS_ATTRIBUTE = namedtuple("business_attribute", ["ce_id", "party_id", "business_name"])
-CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status"])
+CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status", "status_change_time"])
 BUSINESS_ENROLMENT = namedtuple("business_enrolment", ["business_id", "respondent_id", "sample_unit_ref", "status"])
 RESPONDENT = namedtuple(
     "respondent",
@@ -14,9 +14,9 @@ RESPONDENT = namedtuple(
 @pytest.fixture()
 def cases():
     return [
-        CASE("20d2eca7-fc2e-408d-88d4-ae841cee728c", "11110000001", "NOTSTARTED"),
-        CASE("10fbbff8-ec3b-4bdb-bdc4-91a415794fb0", "11110000002", "NOTSTARTED"),
-        CASE("77e9ee23-6d52-4e63-b581-699afbb4acca", "11110000003", "NOTSTARTED"),
+        CASE("20d2eca7-fc2e-408d-88d4-ae841cee728c", "11110000001", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
+        CASE("10fbbff8-ec3b-4bdb-bdc4-91a415794fb0", "11110000002", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
+        CASE("77e9ee23-6d52-4e63-b581-699afbb4acca", "11110000003", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
     ]
 
 
@@ -95,6 +95,7 @@ def expected_report_rows():
             "07000000003",
             "test3@ons.gov.uk",
             "ACTIVE",
+            "2024-01-29 14:16:02.105 +0000",
         ],
         ["NOTSTARTED", "11110000002", "Business 2"],
         [
@@ -106,6 +107,7 @@ def expected_report_rows():
             "07000000001",
             "test1@ons.gov.uk",
             "ACTIVE",
+            "2024-01-29 14:16:02.105 +0000",
         ],
         [
             "NOTSTARTED",
@@ -116,5 +118,6 @@ def expected_report_rows():
             "07000000002",
             "test2@ons.gov.uk",
             "CREATED",
+            "2024-01-29 14:16:02.105 +0000",
         ],
     ]

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from datetime import datetime
 
 import pytest
 
@@ -14,9 +15,24 @@ RESPONDENT = namedtuple(
 @pytest.fixture()
 def cases():
     return [
-        CASE("20d2eca7-fc2e-408d-88d4-ae841cee728c", "11110000001", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
-        CASE("10fbbff8-ec3b-4bdb-bdc4-91a415794fb0", "11110000002", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
-        CASE("77e9ee23-6d52-4e63-b581-699afbb4acca", "11110000003", "NOTSTARTED", "2024-01-29 14:16:02.105 +0000"),
+        CASE(
+            "20d2eca7-fc2e-408d-88d4-ae841cee728c",
+            "11110000001",
+            "NOTSTARTED",
+            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+        ),
+        CASE(
+            "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0",
+            "11110000002",
+            "NOTSTARTED",
+            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+        ),
+        CASE(
+            "77e9ee23-6d52-4e63-b581-699afbb4acca",
+            "11110000003",
+            "NOTSTARTED",
+            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+        ),
     ]
 
 

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 
 BUSINESS_ATTRIBUTE = namedtuple("business_attribute", ["ce_id", "party_id", "business_name"])
-CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status", "change_state_timestamp"])
+CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status", "status_change_timestamp"])
 BUSINESS_ENROLMENT = namedtuple("business_enrolment", ["business_id", "respondent_id", "sample_unit_ref", "status"])
 RESPONDENT = namedtuple(
     "respondent",

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -95,7 +95,7 @@ def expected_report_rows():
             "07000000003",
             "test3@ons.gov.uk",
             "ACTIVE",
-            "2024-01-29 14:16:02.105 +0000",
+            "2024-01-29 14:16:02",
         ],
         ["NOTSTARTED", "11110000002", "Business 2"],
         [
@@ -107,7 +107,7 @@ def expected_report_rows():
             "07000000001",
             "test1@ons.gov.uk",
             "ACTIVE",
-            "2024-01-29 14:16:02.105 +0000",
+            "2024-01-29 14:16:02",
         ],
         [
             "NOTSTARTED",
@@ -118,6 +118,6 @@ def expected_report_rows():
             "07000000002",
             "test2@ons.gov.uk",
             "CREATED",
-            "2024-01-29 14:16:02.105 +0000",
+            "2024-01-29 14:16:02",
         ],
     ]

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 
 BUSINESS_ATTRIBUTE = namedtuple("business_attribute", ["ce_id", "party_id", "business_name"])
-CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status", "status_change_time"])
+CASE = namedtuple("case", ["party_id", "sample_unit_ref", "status", "change_state_timestamp"])
 BUSINESS_ENROLMENT = namedtuple("business_enrolment", ["business_id", "respondent_id", "sample_unit_ref", "status"])
 RESPONDENT = namedtuple(
     "respondent",


### PR DESCRIPTION
# What and why?
There is a requirement to add a datetime for when a respondents status is changed and to display this in the Response Chasing Report. This PR includes the code change to display this datetime.

# How to test?
First deploy https://github.com/ONSdigital/rm-case-service/pull/288
Then update the status of a respondent (either via Frontstage or in rOps) and click the report for the associated survey. This will show the datetime of the status change in both Excel and CSV formates.
Check the unit tests work and that the acceptance tests still work.

# Jira
https://jira.ons.gov.uk/browse/RAS-940