### PR TITLE
RAS-1164 Time stamp 1 hr behind on response chasing reports in PROD

### DIFF
--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.16
+version: 3.0.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.16
+appVersion: 3.0.17

--- a/rm_reporting/controllers/response_chasing_controller.py
+++ b/rm_reporting/controllers/response_chasing_controller.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import IO, Callable
 from uuid import UUID
 
+from dateutil.tz import tz
 from openpyxl import Workbook
 from structlog import wrap_logger
 
@@ -67,7 +68,12 @@ def _add_report_data(ce_id: UUID, survey_id: UUID, document_object, append_funct
         business_attributes = business_attributes_map[str(getattr(case, "party_id"))]
         business_name = getattr(business_attributes, "business_name")
         if getattr(case, "status_change_timestamp"):
-            status_change_timestamp = datetime.strftime(getattr(case, "status_change_timestamp"), "%Y-%m-%d %H:%M:%S")
+            status_change_timestamp = datetime.strftime(
+                getattr(case, "status_change_timestamp")
+                .replace(tzinfo=tz.gettz("UTC"))
+                .astimezone(tz.gettz("Europe/London")),
+                "%Y-%m-%d %H:%M:%S",
+            )
         else:
             status_change_timestamp = ""
 


### PR DESCRIPTION
# What and why?
This PR fixes a bug that was identified when downloading the response chasing report. The time in the timestamp for the respondent status change column was off by 1 hour (daylight savings), causing a discrepancy with the timestamp in the change response status page. We store it in UTC in the database and it was not getting dealt with in reporting as we do in rOps and frontstage, which change the timezone it has attached to it to BST (which takes into consideration UK daylight savings)
# How to test?
- run the EQ acceptance tests in your environment
- download the response chasing report and check that the `Status Change Timestamp` is one hour behind 
   - the current time
   - the time in the change response status page (through the reporting units tab
- deploy this PR to your environment
- download the response chasing report and check that the `Status Change Timestamp` 
   - the current hour
   - the time in the change response status page (through the reporting units tab 
# Jira
[RAS-1164](https://jira.ons.gov.uk/browse/RAS-1164)