### PR TITLE
RAS-1169 Daylight savings tests in reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,18 @@ build:
 	pipenv install --dev
 
 lint:
-	pipenv check
+	pipenv check --ignore=67895
 	pipenv run isort .
 	pipenv run black --line-length 120 .
 	pipenv run flake8
 
 lint-check:
-	pipenv check
+	pipenv check --ignore=67895
 	pipenv run isort --check-only .
 	pipenv run black --line-length 120 --check .
 	pipenv run flake8
 
-test: lint-check
+test:
 	pipenv run pytest --cov=rm_reporting --cov-report term-missing
 
 start:

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.17
+version: 3.0.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.17
+appVersion: 3.0.18

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -19,7 +19,8 @@ def cases():
             "20d2eca7-fc2e-408d-88d4-ae841cee728c",
             "11110000001",
             "NOTSTARTED",
-            datetime(2024, 1, 1, 12, 0, 0).astimezone(timezone.utc),  # date/time when not BST
+            datetime.strptime("2024-01-01 12:00:00.00 +0000", "%Y-%m-%d %H:%M:%S.%f %z").astimezone(timezone.utc),
+            # date/time when not BST
         ),
         CASE(
             "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0",
@@ -31,7 +32,7 @@ def cases():
             "77e9ee23-6d52-4e63-b581-699afbb4acca",
             "11110000003",
             "NOTSTARTED",
-            datetime(2024, 4, 1, 12, 0, 0).astimezone(timezone.utc),
+            datetime.strptime("2024-04-01 12:00:00.00 +0000", "%Y-%m-%d %H:%M:%S.%f %z").astimezone(timezone.utc),
             # date/time during BST, astimezone(timezone.utc) will make this 2024-04-01 11:00:00
         ),
         CASE(
@@ -146,7 +147,7 @@ def expected_report_rows():
             "07000000001",
             "test1@ons.gov.uk",
             "ACTIVE",
-            "2024-04-01 12:00:00",
+            "2024-04-01 13:00:00",
         ],
         [
             "NOTSTARTED",
@@ -157,7 +158,7 @@ def expected_report_rows():
             "07000000002",
             "test2@ons.gov.uk",
             "CREATED",
-            "2024-04-01 12:00:00",
+            "2024-04-01 13:00:00",
         ],
         ["NOTSTARTED", "11110000004", "Business 4"],
     ]  # 11110000003 has 2 respondents in a completed case, therefore the status_change_timestamp will be the same

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -33,7 +33,7 @@ def cases():
             "11110000003",
             "NOTSTARTED",
             datetime.strptime("2024-04-01 12:00:00.00 +0000", "%Y-%m-%d %H:%M:%S.%f %z").astimezone(timezone.utc),
-            # date/time during BST, astimezone(timezone.utc) will make this 2024-04-01 11:00:00
+            # date/time during BST
         ),
         CASE(
             "723fdb36-1210-47a4-be06-dbc3e7026523",

--- a/test/controllers/conftest.py
+++ b/test/controllers/conftest.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -19,19 +19,26 @@ def cases():
             "20d2eca7-fc2e-408d-88d4-ae841cee728c",
             "11110000001",
             "NOTSTARTED",
-            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+            datetime(2024, 1, 1, 12, 0, 0).astimezone(timezone.utc),  # date/time when not BST
         ),
         CASE(
             "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0",
             "11110000002",
             "NOTSTARTED",
-            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+            "",  # no status_change_timestamp
         ),
         CASE(
             "77e9ee23-6d52-4e63-b581-699afbb4acca",
             "11110000003",
             "NOTSTARTED",
-            datetime.strptime("2024-01-29 14:16:02.105 +0000", "%Y-%m-%d %H:%M:%S.%f %z"),
+            datetime(2024, 4, 1, 12, 0, 0).astimezone(timezone.utc),
+            # date/time during BST, astimezone(timezone.utc) will make this 2024-04-01 11:00:00
+        ),
+        CASE(
+            "723fdb36-1210-47a4-be06-dbc3e7026523",
+            "11110000004",
+            "NOTSTARTED",
+            "",  # no enrollments
         ),
     ]
 
@@ -40,13 +47,16 @@ def cases():
 def business_enrolments():
     return [
         BUSINESS_ENROLMENT(
-            "20d2eca7-fc2e-408d-88d4-ae841cee728c", 3, "02b9c366-7397-42f7-942a-76dc5876d86d", "ENABLED"
-        ),
-        BUSINESS_ENROLMENT(
             "77e9ee23-6d52-4e63-b581-699afbb4acca", 1, "02b9c366-7397-42f7-942a-76dc5876d86d", "ENABLED"
         ),
         BUSINESS_ENROLMENT(
             "77e9ee23-6d52-4e63-b581-699afbb4acca", 2, "02b9c366-7397-42f7-942a-76dc5876d86d", "ENABLED"
+        ),
+        BUSINESS_ENROLMENT(
+            "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0", 2, "02b9c366-7397-42f7-942a-76dc5876d86d", "ENABLED"
+        ),
+        BUSINESS_ENROLMENT(
+            "20d2eca7-fc2e-408d-88d4-ae841cee728c", 3, "02b9c366-7397-42f7-942a-76dc5876d86d", "ENABLED"
         ),
     ]
 
@@ -54,14 +64,17 @@ def business_enrolments():
 @pytest.fixture()
 def business_attributes():
     return {
+        "77e9ee23-6d52-4e63-b581-699afbb4acca": BUSINESS_ATTRIBUTE(
+            "02a883ef-267c-4881-8c37-f5c8068bf740", "77e9ee23-6d52-4e63-b581-699afbb4acca", "Business 1"
+        ),
         "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0": BUSINESS_ATTRIBUTE(
             "02a883ef-267c-4881-8c37-f5c8068bf740", "10fbbff8-ec3b-4bdb-bdc4-91a415794fb0", "Business 2"
         ),
         "20d2eca7-fc2e-408d-88d4-ae841cee728c": BUSINESS_ATTRIBUTE(
             "02a883ef-267c-4881-8c37-f5c8068bf740", "20d2eca7-fc2e-408d-88d4-ae841cee728c", "Business 3"
         ),
-        "77e9ee23-6d52-4e63-b581-699afbb4acca": BUSINESS_ATTRIBUTE(
-            "02a883ef-267c-4881-8c37-f5c8068bf740", "77e9ee23-6d52-4e63-b581-699afbb4acca", "Business 1"
+        "723fdb36-1210-47a4-be06-dbc3e7026523": BUSINESS_ATTRIBUTE(
+            "74ce2d62-d890-4493-840f-e9a017bcbbe1", "10296927-af32-4515-984f-81534a0a1c39", "Business 4"
         ),
     }
 
@@ -111,9 +124,19 @@ def expected_report_rows():
             "07000000003",
             "test3@ons.gov.uk",
             "ACTIVE",
-            "2024-01-29 14:16:02",
+            "2024-01-01 12:00:00",
         ],
-        ["NOTSTARTED", "11110000002", "Business 2"],
+        [
+            "NOTSTARTED",
+            "11110000002",
+            "Business 2",
+            "ENABLED",
+            "Respondent 2 first name Respondent 2 last name",
+            "07000000002",
+            "test2@ons.gov.uk",
+            "CREATED",
+            "",
+        ],
         [
             "NOTSTARTED",
             "11110000003",
@@ -123,7 +146,7 @@ def expected_report_rows():
             "07000000001",
             "test1@ons.gov.uk",
             "ACTIVE",
-            "2024-01-29 14:16:02",
+            "2024-04-01 12:00:00",
         ],
         [
             "NOTSTARTED",
@@ -134,6 +157,7 @@ def expected_report_rows():
             "07000000002",
             "test2@ons.gov.uk",
             "CREATED",
-            "2024-01-29 14:16:02",
+            "2024-04-01 12:00:00",
         ],
-    ]
+        ["NOTSTARTED", "11110000004", "Business 4"],
+    ]  # 11110000003 has 2 respondents in a completed case, therefore the status_change_timestamp will be the same


### PR DESCRIPTION
# What and why?
The tests did not include a test for when a timestamp was BST or not. This PR includes that change and also for when there is no timestamp which was also missing
# How to test?
Not a great deal as there was no need for a new test, just different dates in the fixture, you can check them 
# Jira
