### PR TITLE
change responses dashboard logging levels to error

### DIFF
--- a/rm_reporting/resources/responses_dashboard.py
+++ b/rm_reporting/resources/responses_dashboard.py
@@ -52,11 +52,11 @@ class ResponseDashboard(Resource):
     @staticmethod
     def get(survey_id, collection_exercise_id):
         if not parse_uuid(survey_id):
-            logger.info("Responses dashboard endpoint received malformed survey ID", survey_id=survey_id)
+            logger.error("Responses dashboard endpoint received malformed survey ID", survey_id=survey_id)
             abort(400, "Malformed survey ID")
 
         if not parse_uuid(collection_exercise_id):
-            logger.info(
+            logger.error(
                 "Responses dashboard endpoint received malformed collection exercise ID",
                 collection_exercise_id=collection_exercise_id,
             )
@@ -70,7 +70,7 @@ class ResponseDashboard(Resource):
             }
             return jsonify(response)
         except NoDataException:
-            logger.info(
+            logger.error(
                 "No samples found for exercise, either exercise only has "
                 "reporting units starting with 1111 or exercise doesn't exist.",
                 survey_id=survey_id,


### PR DESCRIPTION
# What and why?
Changing the logging levels of responses-dashboard-related logs to `error` so we can have better visualisation of the issues affecting the responses dashboard in preprod.

# How to test?
Just make sure the changes look okay.

# Jira
[Card](https://officefornationalstatistics.atlassian.net/jira/software/c/projects/RAS/boards/1943?selectedIssue=RAS-1685)
