### PR TITLE
implement dependabot ga workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,13 +44,13 @@ jobs:
         run: |
           make test
       - name: Authenticate with Google Cloud
-        if: github.actor != 'anwilkie'
+        if: github.actor != 'dependabot[bot]'
         id: auth
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
-        if: github.actor != 'anwilkie'
+        if: github.actor != 'dependabot[bot]'
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
       - name: Configure Docker for Artifact Registry
         if: github.actor != 'dependabot[bot]'
@@ -59,7 +59,7 @@ jobs:
           gcloud auth configure-docker "$REGISTRY_HOSTNAME"
 
       - name: pr docker tag
-        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
+        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
         id: tag
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -67,15 +67,15 @@ jobs:
           echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
-        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
+        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
         run: |
           docker build  -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} .
       - name: Push dev image
-        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
+        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
-        if: github.actor != 'anwilkie'
+        if: github.actor != 'dependabot[bot]'
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
@@ -163,14 +163,14 @@ jobs:
           echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_ENV
 
       - name: package helm
-        if: github.actor != 'anwilkie'
+        if: github.actor != 'dependabot[bot]'
         run: |
           echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
           helm dep up $CHART_DIRECTORY
           helm package $CHART_DIRECTORY
 
       - name: Publish dev Chart
-        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
+        if: github.ref != 'refs/heads/main' && github.actor != 'dependabot[bot]'
         run: |
           mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,18 +44,22 @@ jobs:
         run: |
           make test
       - name: Authenticate with Google Cloud
+        if: github.actor != 'anwilkie'
         id: auth
         uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
         with:
           credentials_json: ${{ secrets.GCR_KEY }}
       - name: Setup Google Cloud SDK
+        if: github.actor != 'anwilkie'
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
-      - run: |
+      - name: Configure Docker for Artifact Registry
+        if: github.actor != 'dependabot[bot]'
+        run: |
           gcloud auth configure-docker
           gcloud auth configure-docker "$REGISTRY_HOSTNAME"
 
       - name: pr docker tag
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
         id: tag
         run: |
           PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -63,14 +67,15 @@ jobs:
           echo "pr_number=pr-$PR" >> $GITHUB_ENV
         # Build the Docker image
       - name: Build Docker Image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
         run: |
           docker build  -f _infra/docker/Dockerfile -t "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} .
       - name: Push dev image
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
+        if: github.actor != 'anwilkie'
         run: |
           helm template $CHART_DIRECTORY
       - name: Set current tag
@@ -158,13 +163,14 @@ jobs:
           echo "version=$(grep -E "appVersion:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')" >> $GITHUB_ENV
 
       - name: package helm
+        if: github.actor != 'anwilkie'
         run: |
           echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
           helm dep up $CHART_DIRECTORY
           helm package $CHART_DIRECTORY
 
       - name: Publish dev Chart
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' && github.actor != 'anwilkie'
         run: |
           mv $IMAGE-${{ env.HELM_VERSION }}.tgz $IMAGE-${{ env.pr_number }}.tgz
           gsutil cp $IMAGE-*.tgz gs://$ARTIFACT_BUCKET/$IMAGE/

--- a/_infra/helm/reporting/Chart.yaml
+++ b/_infra/helm/reporting/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.27
+version: 3.0.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.27
+appVersion: 3.0.28


### PR DESCRIPTION
# What and why?
Implementing the dependabot-specific GA workflow for this service.

# How to test?
You can't test anything, since this PR only modifies the GA workflow. Instead, look at the changes and make sure they look right.

If you'd like to look at a simulation of what the truncated dependabot workflow looks like, have a look at [this build](https://github.com/ONSdigital/rm-reporting/actions/runs/19430264664/job/55587225402). This build had the the if-statement set to `if: github.actor != 'anwilkie'` so that it skips the same steps it would if dependabot had triggered the build.

# Jira
[Card](https://officefornationalstatistics.atlassian.net/jira/software/c/projects/RAS/boards/1943?selectedIssue=RAS-1756)